### PR TITLE
Rename 'interface' parameters for Qt macros compability

### DIFF
--- a/rpp/sockets.cpp
+++ b/rpp/sockets.cpp
@@ -1576,26 +1576,26 @@ namespace rpp
         return {};
     }
 
-    ipinterface get_ip_interface(const std::string& interface, address_family af)
+    ipinterface get_ip_interface(const std::string& network_interface, address_family af)
     {
-        std::vector<ipinterface> interfaces = ipinterface::get_interfaces(interface, af);
+        std::vector<ipinterface> interfaces = ipinterface::get_interfaces(network_interface, af);
         if (interfaces.empty())
             return {};
-        std::regex pattern { interface };
+        std::regex pattern { network_interface };
         for (const ipinterface& ip : interfaces)
             if (std::regex_search(ip.name, pattern))
                 return ip;
         return interfaces.front();
     }
 
-    std::string get_system_ip(const std::string& interface, address_family af)
+    std::string get_system_ip(const std::string& network_interface, address_family af)
     {
-        return get_ip_interface(interface, af).addr.str();
+        return get_ip_interface(network_interface, af).addr.str();
     }
 
-    std::string get_broadcast_ip(const std::string& interface, address_family af)
+    std::string get_broadcast_ip(const std::string& network_interface, address_family af)
     {
-        return get_ip_interface(interface, af).broadcast.str();
+        return get_ip_interface(network_interface, af).broadcast.str();
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/rpp/sockets.h
+++ b/rpp/sockets.h
@@ -1074,19 +1074,19 @@ namespace rpp
      * @param interface ["eth|lan|wlan"] Main interface name regex pattern to 
      * @param af Address family to use, most commonly AF_IPv4 or AF_IPv6
      */
-    rpp::ipinterface get_ip_interface(const std::string& interface = "eth|lan|wlan", address_family af = AF_IPv4);
+    rpp::ipinterface get_ip_interface(const std::string& network_interface = "eth|lan|wlan", address_family af = AF_IPv4);
 
     /**
      * @returns Main interface IP address of the current system
      * @param interface ["eth|lan|wlan"] Main interface name regex pattern to match
      */
-    std::string get_system_ip(const std::string& interface = "eth|lan|wlan", address_family af = AF_IPv4);
+    std::string get_system_ip(const std::string& network_interface = "eth|lan|wlan", address_family af = AF_IPv4);
 
     /**
      * @returns Main interface Broadcast IP address of the current system
      * @param interface ["eth|lan|wlan"] Main interface name regex pattern to match
      */
-    std::string get_broadcast_ip(const std::string& interface = "eth|lan|wlan", address_family af = AF_IPv4);
+    std::string get_broadcast_ip(const std::string& network_interface = "eth|lan|wlan", address_family af = AF_IPv4);
 
     ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Qt uses 'interface' as macro in their source code, so we need to rename some function parameters in sockets.h to use with Qt