### PR TITLE
sockets: return SE_UNKNOWN on undefined socket err

### DIFF
--- a/src/rpp/sockets.cpp
+++ b/src/rpp/sockets.cpp
@@ -1212,7 +1212,7 @@ namespace rpp
         int errcode = err ? err : os_getsockerr();
         switch (errcode) {
             case 0: return SE_NONE;
-            default: return (socket::error)errcode;
+            default: return SE_UNKNOWN; // unknown error, not in the list below
             case ESOCK(ENETRESET):     return SE_NETRESET;
             case ESOCK(EMSGSIZE):      return SE_MSGSIZE;
             case ESOCK(EINPROGRESS):   return SE_INPROGRESS;


### PR DESCRIPTION
`socket::last_os_socket_err()`:
```c++
// if it's a known error, use a common shorter message:
socket::error errtype = last_os_socket_err_type(errcode);
if (errtype > 0)
    return to_string(errtype);
```
always returned `true` before, because `last_os_socket_err_type()` never returned values less than 0. Now we can actually get OS specific error messages on unknown errors, e.g.:
```
OSError 10013: An attempt was made to access a socket in a way forbidden by its access permissions.
```