### PR TITLE
baremetal: remove exceptions from strview and handle 64-bit atomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Platform detection, compiler macros, and base type definitions. This is the foun
 | [`RPP_64BIT`](src/rpp/config.h#L240) | `1` if compiling for a 64-bit target |
 | [`RPP_LITTLE_ENDIAN`](src/rpp/config.h#L390) | `1` if target is little-endian |
 | [`RPP_BIG_ENDIAN`](src/rpp/config.h#L398) | `1` if target is big-endian |
+| [`RPP_HAS_EXCEPTIONS`](src/rpp/config.h#L408) | `1` if C++ exceptions are enabled. Auto-detected via `_CPPUNWIND` (MSVC), `__EXCEPTIONS`/`__cpp_exceptions` (GCC/Clang). Defaults to `1` on unknown compilers. Can be overridden manually. |
 
 ### Feature Detection
 
@@ -301,16 +302,16 @@ Platform detection, compiler macros, and base type definitions. This is the foun
 
 | Type | Description |
 |------|-------------|
-| [`byte`](src/rpp/config.h#L410) | `unsigned char` |
-| [`ushort`](src/rpp/config.h#L411) | `unsigned short` |
-| [`uint`](src/rpp/config.h#L412) | `unsigned int` |
-| [`ulong`](src/rpp/config.h#L413) | `unsigned long` |
-| [`int16`](src/rpp/config.h#L415) | `short` (16-bit signed) |
-| [`uint16`](src/rpp/config.h#L416) | `unsigned short` (16-bit unsigned) |
-| [`int32`](src/rpp/config.h#L419) | `int` or `long` depending on `RPP_INT_SIZE` (32-bit signed) |
-| [`uint32`](src/rpp/config.h#L420) | `unsigned int` or `unsigned long` (32-bit unsigned) |
-| [`int64`](src/rpp/config.h#L426) | `long long` (64-bit signed) |
-| [`uint64`](src/rpp/config.h#L427) | `unsigned long long` (64-bit unsigned) |
+| [`byte`](src/rpp/config.h#L428) | `unsigned char` |
+| [`ushort`](src/rpp/config.h#L429) | `unsigned short` |
+| [`uint`](src/rpp/config.h#L430) | `unsigned int` |
+| [`ulong`](src/rpp/config.h#L431) | `unsigned long` |
+| [`int16`](src/rpp/config.h#L433) | `short` (16-bit signed) |
+| [`uint16`](src/rpp/config.h#L434) | `unsigned short` (16-bit unsigned) |
+| [`int32`](src/rpp/config.h#L437) | `int` or `long` depending on `RPP_INT_SIZE` (32-bit signed) |
+| [`uint32`](src/rpp/config.h#L438) | `unsigned int` or `unsigned long` (32-bit unsigned) |
+| [`int64`](src/rpp/config.h#L444) | `long long` (64-bit signed) |
+| [`uint64`](src/rpp/config.h#L445) | `unsigned long long` (64-bit unsigned) |
 
 ---
 
@@ -1016,61 +1017,61 @@ Cross-platform path manipulation, directory listing, and filesystem utilities.
 | Function | Description |
 |----------|-------------|
 | [`delete_file(path)`](src/rpp/paths.h#L141) | Delete a single file |
-| [`copy_file(sourceFile, destinationFile)`](src/rpp/paths.h#L151) | Copy file, overwriting destination |
-| [`copy_file_if_needed(sourceFile, destinationFile)`](src/rpp/paths.h#L169) | Copy only if destination doesn't exist |
-| [`copy_file_into_folder(sourceFile, destinationFolder)`](src/rpp/paths.h#L178) | Copy file into a folder |
+| [`copy_file(sourceFile, destinationFile)`](src/rpp/paths.h#L166) | Copy file, overwriting destination |
+| [`copy_file_if_needed(sourceFile, destinationFile)`](src/rpp/paths.h#L184) | Copy only if destination doesn't exist |
+| [`copy_file_into_folder(sourceFile, destinationFolder)`](src/rpp/paths.h#L193) | Copy file into a folder |
 | [`create_symlink(target, link)`](src/rpp/paths.h#L63) | Create a symbolic link |
-| [`copy_file_mode(sourceFile, destinationFile)`](src/rpp/paths.h#L160) | Copies file access permissions from source to destination |
+| [`copy_file_mode(sourceFile, destinationFile)`](src/rpp/paths.h#L175) | Copies file access permissions from source to destination |
 
 ### Folder Operations
 
 | Function | Description |
 |----------|-------------|
-| [`create_folder(foldername)`](src/rpp/paths.h#L188) | Create folder recursively |
-| [`delete_folder(foldername, mode)`](src/rpp/paths.h#L206) | Delete folder (recursive or non-recursive) |
+| [`create_folder(foldername)`](src/rpp/paths.h#L203) | Create folder recursively |
+| [`delete_folder(foldername, mode)`](src/rpp/paths.h#L221) | Delete folder (recursive or non-recursive) |
 
 ### Path Manipulation
 
 | Function | Description |
 |----------|-------------|
-| [`full_path(path)`](src/rpp/paths.h#L215) | Resolve relative path to absolute |
-| [`merge_dirups(path)`](src/rpp/paths.h#L224) | Merge all `../` inside a path |
-| [`file_name(path)`](src/rpp/paths.h#L239) | Extract filename without extension |
-| [`file_nameext(path)`](src/rpp/paths.h#L251) | Extract filename with extension |
-| [`file_ext(path)`](src/rpp/paths.h#L265) | Extract file extension |
-| [`file_replace_ext(path, ext)`](src/rpp/paths.h#L278) | Replace file extension |
-| [`file_name_append(path, add)`](src/rpp/paths.h#L290) | Append to filename (before extension) |
-| [`file_name_replace(path, newFileName)`](src/rpp/paths.h#L302) | Replace only the filename |
-| [`file_nameext_replace(path, newFileNameAndExt)`](src/rpp/paths.h#L314) | Replace filename and extension |
-| [`folder_name(path)`](src/rpp/paths.h#L327) | Extract folder name from path |
-| [`folder_path(path)`](src/rpp/paths.h#L341) | Extract full folder path from file path |
-| [`normalize(path, sep)`](src/rpp/paths.h#L353) | Normalize slashes in-place |
-| [`normalized(path, sep)`](src/rpp/paths.h#L364) | Return normalized copy |
-| [`path_combine(path1, path2, ...)`](src/rpp/paths.h#L376) | Safely combine path segments (up to 4) |
+| [`full_path(path)`](src/rpp/paths.h#L230) | Resolve relative path to absolute |
+| [`merge_dirups(path)`](src/rpp/paths.h#L239) | Merge all `../` inside a path |
+| [`file_name(path)`](src/rpp/paths.h#L254) | Extract filename without extension |
+| [`file_nameext(path)`](src/rpp/paths.h#L266) | Extract filename with extension |
+| [`file_ext(path)`](src/rpp/paths.h#L280) | Extract file extension |
+| [`file_replace_ext(path, ext)`](src/rpp/paths.h#L293) | Replace file extension |
+| [`file_name_append(path, add)`](src/rpp/paths.h#L305) | Append to filename (before extension) |
+| [`file_name_replace(path, newFileName)`](src/rpp/paths.h#L317) | Replace only the filename |
+| [`file_nameext_replace(path, newFileNameAndExt)`](src/rpp/paths.h#L329) | Replace filename and extension |
+| [`folder_name(path)`](src/rpp/paths.h#L342) | Extract folder name from path |
+| [`folder_path(path)`](src/rpp/paths.h#L356) | Extract full folder path from file path |
+| [`normalize(path, sep)`](src/rpp/paths.h#L368) | Normalize slashes in-place |
+| [`normalized(path, sep)`](src/rpp/paths.h#L379) | Return normalized copy |
+| [`path_combine(path1, path2, ...)`](src/rpp/paths.h#L391) | Safely combine path segments (up to 4) |
 
 ### Directory Listing
 
 | Function | Description |
 |----------|-------------|
-| [`list_dirs(out, dir, flags)`](src/rpp/paths.h#L625) | List all folders inside a directory |
-| [`list_files(out,dir, suffix, flags)`](src/rpp/paths.h#L679) | List files with optional extension filter |
-| [`dir_iterator`](src/rpp/paths.h#L557) | Range-based UTF-8 directory iterator |
-| [`udir_iterator`](src/rpp/paths.h#L562) | Range-based UTF-16 directory iterator |
-| [`dir_iter_base`](src/rpp/paths.h#L396) | Common base class for directory iteration |
-| [`directory_iter`](src/rpp/paths.h#L445) | Basic non-recursive directory iterator |
-| [`list_alldir(outDirs, outFiles, dir, flags)`](src/rpp/paths.h#L723) | Lists all directories and files in a directory |
+| [`list_dirs(out, dir, flags)`](src/rpp/paths.h#L640) | List all folders inside a directory |
+| [`list_files(out,dir, suffix, flags)`](src/rpp/paths.h#L694) | List files with optional extension filter |
+| [`dir_iterator`](src/rpp/paths.h#L572) | Range-based UTF-8 directory iterator |
+| [`udir_iterator`](src/rpp/paths.h#L577) | Range-based UTF-16 directory iterator |
+| [`dir_iter_base`](src/rpp/paths.h#L411) | Common base class for directory iteration |
+| [`directory_iter`](src/rpp/paths.h#L460) | Basic non-recursive directory iterator |
+| [`list_alldir(outDirs, outFiles, dir, flags)`](src/rpp/paths.h#L738) | Lists all directories and files in a directory |
 
 ### System Directories
 
 | Function | Description |
 |----------|-------------|
-| [`working_dir()`](src/rpp/paths.h#L736) | Current working directory (with trailing slash) |
-| [`module_dir(moduleObject)`](src/rpp/paths.h#L766) | Directory of the current linked module |
-| [`temp_dir()`](src/rpp/paths.h#L793) | System temporary directory |
-| [`home_dir()`](src/rpp/paths.h#L804) | User home directory |
-| [`module_path(moduleObject)`](src/rpp/paths.h#L774) | Full path to enclosing binary including filename |
-| [`change_dir(new_wd)`](src/rpp/paths.h#L781) | Changes the application working directory |
-| [`home_diru()`](src/rpp/paths.h#L806) | User home directory as Unicode ustring |
+| [`working_dir()`](src/rpp/paths.h#L751) | Current working directory (with trailing slash) |
+| [`module_dir(moduleObject)`](src/rpp/paths.h#L781) | Directory of the current linked module |
+| [`temp_dir()`](src/rpp/paths.h#L808) | System temporary directory |
+| [`home_dir()`](src/rpp/paths.h#L819) | User home directory |
+| [`module_path(moduleObject)`](src/rpp/paths.h#L789) | Full path to enclosing binary including filename |
+| [`change_dir(new_wd)`](src/rpp/paths.h#L796) | Changes the application working directory |
+| [`home_diru()`](src/rpp/paths.h#L821) | User home directory as Unicode ustring |
 
 ### Example using paths.h for path manipulation and directory listing:
 

--- a/src/rpp/config.h
+++ b/src/rpp/config.h
@@ -402,6 +402,24 @@
 #  endif
 #endif
 
+#ifndef RPP_HAS_EXCEPTIONS
+#  if defined(_MSC_VER)
+#    if defined(_CPPUNWIND)
+#      define RPP_HAS_EXCEPTIONS 1
+#    else
+#      define RPP_HAS_EXCEPTIONS 0
+#    endif
+#  elif defined(__GNUC__) || defined(__clang__)
+#    if defined(__EXCEPTIONS) || defined(__cpp_exceptions)
+#      define RPP_HAS_EXCEPTIONS 1
+#    else
+#      define RPP_HAS_EXCEPTIONS 0
+#    endif
+#  else
+#    define RPP_HAS_EXCEPTIONS 1 // By default, assume exceptions are supported
+#  endif
+#endif
+
 #ifdef __cplusplus
 namespace rpp
 {

--- a/src/rpp/debugging.cpp
+++ b/src/rpp/debugging.cpp
@@ -2,6 +2,9 @@
 #include "timer.h" // rpp::TimePoint
 #include "stack_trace.h"
 #include "strview.h"
+#if RPP_CORTEX_M_ARCH
+# include "mutex.h" // rpp::critical_section
+#endif
 
 #include <atomic>
 #include <array>
@@ -63,7 +66,12 @@ static std::atomic<bool> DisableFunctionNames {false};
 static std::atomic<bool> EnableTimestamps {false};
 static std::atomic<bool> TimeOfDay {false};
 static std::atomic<int> TimePrecision {3};
-static std::atomic<rpp::int64> TimeOffset {0};
+#if RPP_CORTEX_M_ARCH
+    // no 64-bit atomics on Cortex systems
+    static rpp::int64 TimeOffset {0};
+#else
+    static std::atomic<rpp::int64> TimeOffset {0};
+#endif
 
 // new logging API
 namespace rpp
@@ -161,7 +169,13 @@ RPPCAPI void LogEnableTimestamps(bool enable, int precision, bool time_of_day) n
 }
 RPPCAPI void LogSetTimeOffset(rpp::int64 offset) noexcept
 {
+#if RPP_CORTEX_M_ARCH
+    rpp::critical_section mut{};
+    std::lock_guard<rpp::critical_section> guard{mut};
+    TimeOffset = offset;
+#else
     TimeOffset.store(offset, std::memory_order_release);
+#endif
 }
 
 static int SafeFormat(char* errBuf, int N, const char* format, va_list ap) noexcept
@@ -172,7 +186,15 @@ static int SafeFormat(char* errBuf, int N, const char* format, va_list ap) noexc
 
     if (EnableTimestamps) {
         rpp::TimePoint now = rpp::TimePoint::system_now();
+    #if RPP_CORTEX_M_ARCH
+        {
+            rpp::critical_section mut{};
+            std::lock_guard<rpp::critical_section> guard{mut};
+            now.duration.nsec += TimeOffset;
+        }
+    #else
         now.duration.nsec += TimeOffset.load(std::memory_order_relaxed);
+    #endif
         if (TimeOfDay)
             len = now.time_of_day().to_string(pbuf, remaining-1, TimePrecision);
         else

--- a/src/rpp/debugging.cpp
+++ b/src/rpp/debugging.cpp
@@ -69,6 +69,7 @@ static std::atomic<int> TimePrecision {3};
 #if RPP_CORTEX_M_ARCH
     // no 64-bit atomics on Cortex systems
     static rpp::int64 TimeOffset {0};
+    static rpp::critical_section LogMutex;
 #else
     static std::atomic<rpp::int64> TimeOffset {0};
 #endif
@@ -170,8 +171,7 @@ RPPCAPI void LogEnableTimestamps(bool enable, int precision, bool time_of_day) n
 RPPCAPI void LogSetTimeOffset(rpp::int64 offset) noexcept
 {
 #if RPP_CORTEX_M_ARCH
-    rpp::critical_section mut{};
-    std::lock_guard<rpp::critical_section> guard{mut};
+    std::lock_guard<rpp::critical_section> guard{LogMutex};
     TimeOffset = offset;
 #else
     TimeOffset.store(offset, std::memory_order_release);
@@ -188,8 +188,7 @@ static int SafeFormat(char* errBuf, int N, const char* format, va_list ap) noexc
         rpp::TimePoint now = rpp::TimePoint::system_now();
     #if RPP_CORTEX_M_ARCH
         {
-            rpp::critical_section mut{};
-            std::lock_guard<rpp::critical_section> guard{mut};
+            std::lock_guard<rpp::critical_section> guard{LogMutex};
             now.duration.nsec += TimeOffset;
         }
     #else

--- a/src/rpp/strview.cpp
+++ b/src/rpp/strview.cpp
@@ -587,7 +587,9 @@ namespace rpp
     string strview::as_lower() const noexcept
     {
         string ret;
-        try { ret.reserve(size_t(len)); } catch (...) { return ret; }
+        size_t current_len = size_t(len);
+        if (current_len > ret.max_size()) return ret;
+        ret.reserve(current_len);
         char* s = const_cast<char*>(str);
         for (int n = len; n > 0; --n)
             ret.push_back(static_cast<char>(::tolower(*s++)));
@@ -596,7 +598,9 @@ namespace rpp
     string strview::as_upper() const noexcept
     {
         string ret;
-        try { ret.reserve(size_t(len)); } catch (...) { return ret; }
+        size_t current_len = size_t(len);
+        if (current_len > ret.max_size()) return ret;
+        ret.reserve(current_len);
         char* s = const_cast<char*>(str);
         for (int n = len; n > 0; --n)
             ret.push_back(static_cast<char>(::toupper(*s++)));

--- a/src/rpp/strview.cpp
+++ b/src/rpp/strview.cpp
@@ -588,8 +588,12 @@ namespace rpp
     {
         string ret;
         size_t current_len = size_t(len);
-        if (current_len > ret.max_size()) return ret;
-        ret.reserve(current_len);
+        #if RPP_HAS_EXCEPTIONS == 1
+            try { ret.reserve(current_len); } catch (...) { return ret; }
+        #else
+            if (current_len > ret.max_size()) return ret; // Handle negative len
+            ret.reserve(current_len);
+        #endif
         char* s = const_cast<char*>(str);
         for (int n = len; n > 0; --n)
             ret.push_back(static_cast<char>(::tolower(*s++)));
@@ -599,8 +603,12 @@ namespace rpp
     {
         string ret;
         size_t current_len = size_t(len);
-        if (current_len > ret.max_size()) return ret;
-        ret.reserve(current_len);
+        #if RPP_HAS_EXCEPTIONS == 1
+            try { ret.reserve(current_len); } catch (...) { return ret; }
+        #else
+            if (current_len > ret.max_size()) return ret; // Handle negative len
+            ret.reserve(current_len);
+        #endif
         char* s = const_cast<char*>(str);
         for (int n = len; n > 0; --n)
             ret.push_back(static_cast<char>(::toupper(*s++)));

--- a/src/rpp/strview.cpp
+++ b/src/rpp/strview.cpp
@@ -587,31 +587,39 @@ namespace rpp
     string strview::as_lower() const noexcept
     {
         string ret;
-        size_t current_len = size_t(len);
+        const size_t current_len = size_t(len);
+        if (current_len > ret.max_size()) return ret; // Negative len becomes huge size_t, handle that case
+
         #if RPP_HAS_EXCEPTIONS == 1
-            try { ret.reserve(current_len); } catch (...) { return ret; }
-        #else
-            if (current_len > ret.max_size()) return ret; // Handle negative len
-            ret.reserve(current_len);
+            try {
         #endif
-        char* s = const_cast<char*>(str);
-        for (int n = len; n > 0; --n)
-            ret.push_back(static_cast<char>(::tolower(*s++)));
+                ret.reserve(current_len);
+                for (size_t i = 0; i < current_len; ++i)
+                    ret.push_back(static_cast<char>(::tolower(str[i])));
+        #if RPP_HAS_EXCEPTIONS == 1
+            } catch (...) {
+                return string{};
+            }
+        #endif
         return ret;
     }
     string strview::as_upper() const noexcept
     {
         string ret;
         size_t current_len = size_t(len);
+        if (current_len > ret.max_size()) return ret; // Negative len becomes huge size_t, handle that case
+
         #if RPP_HAS_EXCEPTIONS == 1
-            try { ret.reserve(current_len); } catch (...) { return ret; }
-        #else
-            if (current_len > ret.max_size()) return ret; // Handle negative len
-            ret.reserve(current_len);
+            try {
         #endif
-        char* s = const_cast<char*>(str);
-        for (int n = len; n > 0; --n)
-            ret.push_back(static_cast<char>(::toupper(*s++)));
+                ret.reserve(current_len);
+                for (size_t i = 0; i < current_len; ++i)
+                    ret.push_back(static_cast<char>(::toupper(str[i])));
+        #if RPP_HAS_EXCEPTIONS == 1
+            } catch (...) {
+                return string{};
+            }
+        #endif
         return ret;
     }
 


### PR DESCRIPTION
Two things in this PR:
1. A month ago during a refactor, two try-catch blocks were added to strview. I replaced them with proactive checks so the source is still compilable on systems with no exceptions.
2. Debugging started using std::atomic. While 32-bit std::atomics work fine on cortex-m systems, there is no support for 64-bit types. I handled it by manually disabling interrupts every time the atomic is handled.