### PR TITLE
Make readBE/writeBE endian helpers alignment-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -3983,23 +3983,23 @@ Endian byte-swap read/write utilities for big-endian and little-endian data.
 
 | Function | Description |
 |----------|-------------|
-| [`writeBEU16(out, value)`](src/rpp/endian.h#L46) | Write 16-bit big-endian |
-| [`writeBEU32(out, value)`](src/rpp/endian.h#L51) | Write 32-bit big-endian |
-| [`writeBEU64(out, value)`](src/rpp/endian.h#L56) | Write 64-bit big-endian |
-| [`readBEU16(in)`](src/rpp/endian.h#L61) | Read 16-bit big-endian |
-| [`readBEU32(in)`](src/rpp/endian.h#L66) | Read 32-bit big-endian |
-| [`readBEU64(in)`](src/rpp/endian.h#L71) | Read 64-bit big-endian |
+| [`writeBEU16(out, value)`](src/rpp/endian.h#L54) | Write 16-bit big-endian |
+| [`writeBEU32(out, value)`](src/rpp/endian.h#L61) | Write 32-bit big-endian |
+| [`writeBEU64(out, value)`](src/rpp/endian.h#L70) | Write 64-bit big-endian |
+| [`readBEU16(in)`](src/rpp/endian.h#L83) | Read 16-bit big-endian |
+| [`readBEU32(in)`](src/rpp/endian.h#L89) | Read 32-bit big-endian |
+| [`readBEU64(in)`](src/rpp/endian.h#L95) | Read 64-bit big-endian |
 
 ### Little-Endian
 
 | Function | Description |
 |----------|-------------|
-| [`writeLEU16(out, value)`](src/rpp/endian.h#L80) | Write 16-bit little-endian |
-| [`writeLEU32(out, value)`](src/rpp/endian.h#L85) | Write 32-bit little-endian |
-| [`writeLEU64(out, value)`](src/rpp/endian.h#L90) | Write 64-bit little-endian |
-| [`readLEU16(in)`](src/rpp/endian.h#L95) | Read 16-bit little-endian |
-| [`readLEU32(in)`](src/rpp/endian.h#L100) | Read 32-bit little-endian |
-| [`readLEU64(in)`](src/rpp/endian.h#L105) | Read 64-bit little-endian |
+| [`writeLEU16(out, value)`](src/rpp/endian.h#L106) | Write 16-bit little-endian |
+| [`writeLEU32(out, value)`](src/rpp/endian.h#L113) | Write 32-bit little-endian |
+| [`writeLEU64(out, value)`](src/rpp/endian.h#L122) | Write 64-bit little-endian |
+| [`readLEU16(in)`](src/rpp/endian.h#L135) | Read 16-bit little-endian |
+| [`readLEU32(in)`](src/rpp/endian.h#L141) | Read 32-bit little-endian |
+| [`readLEU64(in)`](src/rpp/endian.h#L147) | Read 64-bit little-endian |
 | [`RPP_BYTESWAP16(x)`](src/rpp/endian.h#L17) | Platform-specific 16-bit byte swap |
 | [`RPP_BYTESWAP32(x)`](src/rpp/endian.h#L18) | Platform-specific 32-bit byte swap |
 | [`RPP_BYTESWAP64(x)`](src/rpp/endian.h#L19) | Platform-specific 64-bit byte swap |

--- a/src/rpp/endian.h
+++ b/src/rpp/endian.h
@@ -7,6 +7,7 @@
 #include <cstdint> // uint32_t, uint64_t
 #if _MSC_VER
 #  include <stdlib.h> // _byteswap_ulong, _byteswap_uint64
+#  include <cstring> // memcpy
 #else
 #  include <byteswap.h> // __builtin_bswap32, __builtin_bswap64
 #endif
@@ -17,10 +18,12 @@ namespace rpp
         #define RPP_BYTESWAP16(x) _byteswap_ushort(x)
         #define RPP_BYTESWAP32(x) _byteswap_ulong(x)
         #define RPP_BYTESWAP64(x) _byteswap_uint64(x)
+        #define RPP_BUILTIN_MEMCPY(dst, src, size) memcpy(dst, src, size)
     #else
         #define RPP_BYTESWAP16(x) __builtin_bswap16(x)
         #define RPP_BYTESWAP32(x) __builtin_bswap32(x)
         #define RPP_BYTESWAP64(x) __builtin_bswap64(x)
+        #define RPP_BUILTIN_MEMCPY(dst, src, size) __builtin_memcpy(dst, src, size)
     #endif
 
     #if RPP_LITTLE_ENDIAN
@@ -39,13 +42,14 @@ namespace rpp
         #define RPP_TO_LITTLE64(x) RPP_BYTESWAP64(x)
     #endif
 
-    // The read/write helpers compose the value one byte at a time instead of
-    // dereferencing *reinterpret_cast<T*>(ptr). This is safe at any alignment:
-    // callers commonly read/write packed fields at odd byte offsets, where an
-    // unaligned T* access is undefined behaviour and faults on strict-alignment
-    // targets (ARM/AVR32). The byte order is explicit, so the helpers are also
-    // host-endian-independent; the compiler folds the byte shifts back into a
-    // single load/store + bswap where unaligned access is allowed.
+    // The read/write helpers load/store through RPP_BUILTIN_MEMCPY rather than
+    // *reinterpret_cast<T*>(ptr). A T* access at a non-T-aligned address is UB:
+    // the standard lets the compiler assume the alignment, so optimizers
+    // (store-merging, vectorization) may emit aligned-only instructions that
+    // fault on the packed odd-offset fields these helpers exist to serve. The
+    // hazard is independent of hardware. RPP_BUILTIN_MEMCPY keeps the bswap
+    // intrinsic for the conversion while doing an alignment-safe load/store that
+    // the compiler folds to a single instruction.
 
     /////////////////////////////////////////////////////////////////////
     //// BIG ENDIAN
@@ -53,50 +57,41 @@ namespace rpp
     /** @brief Write a 16-bit unsigned integer in big-endian format */
     inline void writeBEU16(void* out, uint16_t value) noexcept
     {
-        uint8_t* p = static_cast<uint8_t*>(out);
-        p[0] = uint8_t(value >> 8);
-        p[1] = uint8_t(value);
+        uint16_t be_value = RPP_TO_BIG16(value);
+        RPP_BUILTIN_MEMCPY(out, &be_value, sizeof(be_value));
     }
     /** @brief Write a 32-bit unsigned integer in big-endian format */
     inline void writeBEU32(void* out, uint32_t value) noexcept
     {
-        uint8_t* p = static_cast<uint8_t*>(out);
-        p[0] = uint8_t(value >> 24);
-        p[1] = uint8_t(value >> 16);
-        p[2] = uint8_t(value >> 8);
-        p[3] = uint8_t(value);
+        uint32_t be_value = RPP_TO_BIG32(value);
+        RPP_BUILTIN_MEMCPY(out, &be_value, sizeof(be_value));
     }
     /** @brief Write a 64-bit unsigned integer in big-endian format */
     inline void writeBEU64(void* out, uint64_t value) noexcept
     {
-        uint8_t* p = static_cast<uint8_t*>(out);
-        p[0] = uint8_t(value >> 56);
-        p[1] = uint8_t(value >> 48);
-        p[2] = uint8_t(value >> 40);
-        p[3] = uint8_t(value >> 32);
-        p[4] = uint8_t(value >> 24);
-        p[5] = uint8_t(value >> 16);
-        p[6] = uint8_t(value >> 8);
-        p[7] = uint8_t(value);
+        uint64_t be_value = RPP_TO_BIG64(value);
+        RPP_BUILTIN_MEMCPY(out, &be_value, sizeof(be_value));
     }
     /** @brief Read a 16-bit unsigned integer in big-endian format to machine format*/
     inline uint16_t readBEU16(const void* in) noexcept
     {
-        const uint8_t* p = static_cast<const uint8_t*>(in);
-        return uint16_t(uint16_t(p[0]) << 8 | uint16_t(p[1]));
+        uint16_t v;
+        RPP_BUILTIN_MEMCPY(&v, in, sizeof(v));
+        return RPP_TO_BIG16(v);
     }
     /** @brief Read a 32-bit unsigned integer in big-endian format to machine format */
     inline uint32_t readBEU32(const void* in) noexcept
     {
-        const uint8_t* p = static_cast<const uint8_t*>(in);
-        return uint32_t(p[0]) << 24 | uint32_t(p[1]) << 16 | uint32_t(p[2]) << 8 | uint32_t(p[3]);
+        uint32_t v;
+        RPP_BUILTIN_MEMCPY(&v, in, sizeof(v));
+        return RPP_TO_BIG32(v);
     }
     /** @brief Read a 64-bit unsigned integer in big-endian format to machine format */
     inline uint64_t readBEU64(const void* in) noexcept
     {
-        const uint8_t* p = static_cast<const uint8_t*>(in);
-        return uint64_t(p[0]) << 56 | uint64_t(p[1]) << 48 | uint64_t(p[2]) << 40 | uint64_t(p[3]) << 32
-             | uint64_t(p[4]) << 24 | uint64_t(p[5]) << 16 | uint64_t(p[6]) << 8  | uint64_t(p[7]);
+        uint64_t v;
+        RPP_BUILTIN_MEMCPY(&v, in, sizeof(v));
+        return RPP_TO_BIG64(v);
     }
 
     /////////////////////////////////////////////////////////////////////
@@ -105,50 +100,41 @@ namespace rpp
     /** @brief Write a 16-bit unsigned integer in little-endian format */
     inline void writeLEU16(void* out, uint16_t value) noexcept
     {
-        uint8_t* p = static_cast<uint8_t*>(out);
-        p[0] = uint8_t(value);
-        p[1] = uint8_t(value >> 8);
+        uint16_t le_value = RPP_TO_LITTLE16(value);
+        RPP_BUILTIN_MEMCPY(out, &le_value, sizeof(le_value));
     }
     /** @brief Write a 32-bit unsigned integer in little-endian format */
     inline void writeLEU32(void* out, uint32_t value) noexcept
     {
-        uint8_t* p = static_cast<uint8_t*>(out);
-        p[0] = uint8_t(value);
-        p[1] = uint8_t(value >> 8);
-        p[2] = uint8_t(value >> 16);
-        p[3] = uint8_t(value >> 24);
+        uint32_t le_value = RPP_TO_LITTLE32(value);
+        RPP_BUILTIN_MEMCPY(out, &le_value, sizeof(le_value));
     }
     /** @brief Write a 64-bit unsigned integer in little-endian format */
     inline void writeLEU64(void* out, uint64_t value) noexcept
     {
-        uint8_t* p = static_cast<uint8_t*>(out);
-        p[0] = uint8_t(value);
-        p[1] = uint8_t(value >> 8);
-        p[2] = uint8_t(value >> 16);
-        p[3] = uint8_t(value >> 24);
-        p[4] = uint8_t(value >> 32);
-        p[5] = uint8_t(value >> 40);
-        p[6] = uint8_t(value >> 48);
-        p[7] = uint8_t(value >> 56);
+        uint64_t le_value = RPP_TO_LITTLE64(value);
+        RPP_BUILTIN_MEMCPY(out, &le_value, sizeof(le_value));
     }
     /** @brief Read a 16-bit unsigned integer in little-endian format to machine format */
     inline uint16_t readLEU16(const void* in) noexcept
     {
-        const uint8_t* p = static_cast<const uint8_t*>(in);
-        return uint16_t(uint16_t(p[0]) | uint16_t(p[1]) << 8);
+        uint16_t v;
+        RPP_BUILTIN_MEMCPY(&v, in, sizeof(v));
+        return RPP_TO_LITTLE16(v);
     }
     /** @brief Read a 32-bit unsigned integer in little-endian format to machine format */
     inline uint32_t readLEU32(const void* in) noexcept
     {
-        const uint8_t* p = static_cast<const uint8_t*>(in);
-        return uint32_t(p[0]) | uint32_t(p[1]) << 8 | uint32_t(p[2]) << 16 | uint32_t(p[3]) << 24;
+        uint32_t v;
+        RPP_BUILTIN_MEMCPY(&v, in, sizeof(v));
+        return RPP_TO_LITTLE32(v);
     }
     /** @brief Read a 64-bit unsigned integer in little-endian format to machine format */
     inline uint64_t readLEU64(const void* in) noexcept
     {
-        const uint8_t* p = static_cast<const uint8_t*>(in);
-        return uint64_t(p[0]) | uint64_t(p[1]) << 8 | uint64_t(p[2]) << 16 | uint64_t(p[3]) << 24
-             | uint64_t(p[4]) << 32 | uint64_t(p[5]) << 40 | uint64_t(p[6]) << 48 | uint64_t(p[7]) << 56;
+        uint64_t v;
+        RPP_BUILTIN_MEMCPY(&v, in, sizeof(v));
+        return RPP_TO_LITTLE64(v);
     }
 
     /////////////////////////////////////////////////////////////////////

--- a/src/rpp/endian.h
+++ b/src/rpp/endian.h
@@ -39,38 +39,64 @@ namespace rpp
         #define RPP_TO_LITTLE64(x) RPP_BYTESWAP64(x)
     #endif
 
+    // The read/write helpers compose the value one byte at a time instead of
+    // dereferencing *reinterpret_cast<T*>(ptr). This is safe at any alignment:
+    // callers commonly read/write packed fields at odd byte offsets, where an
+    // unaligned T* access is undefined behaviour and faults on strict-alignment
+    // targets (ARM/AVR32). The byte order is explicit, so the helpers are also
+    // host-endian-independent; the compiler folds the byte shifts back into a
+    // single load/store + bswap where unaligned access is allowed.
+
     /////////////////////////////////////////////////////////////////////
     //// BIG ENDIAN
 
     /** @brief Write a 16-bit unsigned integer in big-endian format */
     inline void writeBEU16(void* out, uint16_t value) noexcept
     {
-        *reinterpret_cast<uint16_t*>(out) = RPP_TO_BIG16(value);
+        uint8_t* p = static_cast<uint8_t*>(out);
+        p[0] = uint8_t(value >> 8);
+        p[1] = uint8_t(value);
     }
     /** @brief Write a 32-bit unsigned integer in big-endian format */
     inline void writeBEU32(void* out, uint32_t value) noexcept
     {
-        *reinterpret_cast<uint32_t*>(out) = RPP_TO_BIG32(value);
+        uint8_t* p = static_cast<uint8_t*>(out);
+        p[0] = uint8_t(value >> 24);
+        p[1] = uint8_t(value >> 16);
+        p[2] = uint8_t(value >> 8);
+        p[3] = uint8_t(value);
     }
     /** @brief Write a 64-bit unsigned integer in big-endian format */
     inline void writeBEU64(void* out, uint64_t value) noexcept
     {
-        *reinterpret_cast<uint64_t*>(out) = RPP_TO_BIG64(value);
+        uint8_t* p = static_cast<uint8_t*>(out);
+        p[0] = uint8_t(value >> 56);
+        p[1] = uint8_t(value >> 48);
+        p[2] = uint8_t(value >> 40);
+        p[3] = uint8_t(value >> 32);
+        p[4] = uint8_t(value >> 24);
+        p[5] = uint8_t(value >> 16);
+        p[6] = uint8_t(value >> 8);
+        p[7] = uint8_t(value);
     }
     /** @brief Read a 16-bit unsigned integer in big-endian format to machine format*/
     inline uint16_t readBEU16(const void* in) noexcept
     {
-        return RPP_TO_BIG16(*reinterpret_cast<const uint16_t*>(in));
+        const uint8_t* p = static_cast<const uint8_t*>(in);
+        return uint16_t(uint16_t(p[0]) << 8 | uint16_t(p[1]));
     }
     /** @brief Read a 32-bit unsigned integer in big-endian format to machine format */
     inline uint32_t readBEU32(const void* in) noexcept
     {
-        return RPP_TO_BIG32(*reinterpret_cast<const uint32_t*>(in));
+        const uint8_t* p = static_cast<const uint8_t*>(in);
+        return uint32_t(p[0]) << 24 | uint32_t(p[1]) << 16 | uint32_t(p[2]) << 8 | uint32_t(p[3]);
     }
     /** @brief Read a 64-bit unsigned integer in big-endian format to machine format */
     inline uint64_t readBEU64(const void* in) noexcept
     {
-        return RPP_TO_BIG64(*reinterpret_cast<const uint64_t*>(in));
+        const uint8_t* p = static_cast<const uint8_t*>(in);
+        return uint64_t(p[0]) << 56 | uint64_t(p[1]) << 48 | uint64_t(p[2]) << 40 | uint64_t(p[3]) << 32
+             | uint64_t(p[4]) << 24 | uint64_t(p[5]) << 16 | uint64_t(p[6]) << 8  | uint64_t(p[7]);
     }
 
     /////////////////////////////////////////////////////////////////////
@@ -79,32 +105,50 @@ namespace rpp
     /** @brief Write a 16-bit unsigned integer in little-endian format */
     inline void writeLEU16(void* out, uint16_t value) noexcept
     {
-        *reinterpret_cast<uint16_t*>(out) = RPP_TO_LITTLE16(value);
+        uint8_t* p = static_cast<uint8_t*>(out);
+        p[0] = uint8_t(value);
+        p[1] = uint8_t(value >> 8);
     }
     /** @brief Write a 32-bit unsigned integer in little-endian format */
     inline void writeLEU32(void* out, uint32_t value) noexcept
     {
-        *reinterpret_cast<uint32_t*>(out) = RPP_TO_LITTLE32(value);
+        uint8_t* p = static_cast<uint8_t*>(out);
+        p[0] = uint8_t(value);
+        p[1] = uint8_t(value >> 8);
+        p[2] = uint8_t(value >> 16);
+        p[3] = uint8_t(value >> 24);
     }
     /** @brief Write a 64-bit unsigned integer in little-endian format */
     inline void writeLEU64(void* out, uint64_t value) noexcept
     {
-        *reinterpret_cast<uint64_t*>(out) = RPP_TO_LITTLE64(value);
+        uint8_t* p = static_cast<uint8_t*>(out);
+        p[0] = uint8_t(value);
+        p[1] = uint8_t(value >> 8);
+        p[2] = uint8_t(value >> 16);
+        p[3] = uint8_t(value >> 24);
+        p[4] = uint8_t(value >> 32);
+        p[5] = uint8_t(value >> 40);
+        p[6] = uint8_t(value >> 48);
+        p[7] = uint8_t(value >> 56);
     }
     /** @brief Read a 16-bit unsigned integer in little-endian format to machine format */
     inline uint16_t readLEU16(const void* in) noexcept
     {
-        return RPP_TO_LITTLE16(*reinterpret_cast<const uint16_t*>(in));
+        const uint8_t* p = static_cast<const uint8_t*>(in);
+        return uint16_t(uint16_t(p[0]) | uint16_t(p[1]) << 8);
     }
     /** @brief Read a 32-bit unsigned integer in little-endian format to machine format */
     inline uint32_t readLEU32(const void* in) noexcept
     {
-        return RPP_TO_LITTLE32(*reinterpret_cast<const uint32_t*>(in));
+        const uint8_t* p = static_cast<const uint8_t*>(in);
+        return uint32_t(p[0]) | uint32_t(p[1]) << 8 | uint32_t(p[2]) << 16 | uint32_t(p[3]) << 24;
     }
     /** @brief Read a 64-bit unsigned integer in little-endian format to machine format */
     inline uint64_t readLEU64(const void* in) noexcept
     {
-        return RPP_TO_LITTLE64(*reinterpret_cast<const uint64_t*>(in));
+        const uint8_t* p = static_cast<const uint8_t*>(in);
+        return uint64_t(p[0]) | uint64_t(p[1]) << 8 | uint64_t(p[2]) << 16 | uint64_t(p[3]) << 24
+             | uint64_t(p[4]) << 32 | uint64_t(p[5]) << 40 | uint64_t(p[6]) << 48 | uint64_t(p[7]) << 56;
     }
 
     /////////////////////////////////////////////////////////////////////

--- a/tests/test_endian.cpp
+++ b/tests/test_endian.cpp
@@ -1,0 +1,89 @@
+#include <rpp/endian.h>
+#include <rpp/tests.h>
+#include <cstdint>
+
+TestImpl(test_endian)
+{
+    TestInit(test_endian)
+    {
+    }
+
+    TestCase(big_endian_byte_order)
+    {
+        uint8_t buf[8] = {0};
+
+        rpp::writeBEU16(buf, 0x1122);
+        AssertEqual(buf[0], uint8_t(0x11));
+        AssertEqual(buf[1], uint8_t(0x22));
+
+        rpp::writeBEU32(buf, 0x11223344u);
+        AssertEqual(buf[0], uint8_t(0x11));
+        AssertEqual(buf[1], uint8_t(0x22));
+        AssertEqual(buf[2], uint8_t(0x33));
+        AssertEqual(buf[3], uint8_t(0x44));
+
+        rpp::writeBEU64(buf, 0x1122334455667788ull);
+        AssertEqual(buf[0], uint8_t(0x11));
+        AssertEqual(buf[7], uint8_t(0x88));
+    }
+
+    TestCase(little_endian_byte_order)
+    {
+        uint8_t buf[8] = {0};
+
+        rpp::writeLEU16(buf, 0x1122);
+        AssertEqual(buf[0], uint8_t(0x22));
+        AssertEqual(buf[1], uint8_t(0x11));
+
+        rpp::writeLEU32(buf, 0x11223344u);
+        AssertEqual(buf[0], uint8_t(0x44));
+        AssertEqual(buf[3], uint8_t(0x11));
+
+        rpp::writeLEU64(buf, 0x1122334455667788ull);
+        AssertEqual(buf[0], uint8_t(0x88));
+        AssertEqual(buf[7], uint8_t(0x11));
+    }
+
+    TestCase(roundtrip_all_widths)
+    {
+        uint8_t buf[8];
+
+        rpp::writeBEU16(buf, 0xABCD);
+        AssertEqual(rpp::readBEU16(buf), uint16_t(0xABCD));
+        rpp::writeBEU32(buf, 0xABCD1234u);
+        AssertEqual(rpp::readBEU32(buf), 0xABCD1234u);
+        rpp::writeBEU64(buf, 0xABCD1234DEADBEEFull);
+        AssertEqual(rpp::readBEU64(buf), 0xABCD1234DEADBEEFull);
+
+        rpp::writeLEU16(buf, 0xABCD);
+        AssertEqual(rpp::readLEU16(buf), uint16_t(0xABCD));
+        rpp::writeLEU32(buf, 0xABCD1234u);
+        AssertEqual(rpp::readLEU32(buf), 0xABCD1234u);
+        rpp::writeLEU64(buf, 0xABCD1234DEADBEEFull);
+        AssertEqual(rpp::readLEU64(buf), 0xABCD1234DEADBEEFull);
+    }
+
+    // The reason these helpers go through memcpy: they must work at unaligned offsets.
+    // A reinterpret_cast<uint16_t*> store/load at an odd offset is undefined behaviour and
+    // faults on strict-alignment targets (ARM/AVR32). Exercise every offset 1..7.
+    TestCase(unaligned_offsets_roundtrip)
+    {
+        alignas(8) uint8_t buf[16] = {0};
+
+        for (int off = 1; off <= 7; ++off)
+        {
+            uint8_t* p = buf + off;
+
+            rpp::writeBEU16(p, 0x1234);
+            AssertEqual(rpp::readBEU16(p), uint16_t(0x1234));
+            AssertEqual(p[0], uint8_t(0x12)); // still big-endian at the offset
+            AssertEqual(p[1], uint8_t(0x34));
+
+            rpp::writeLEU32(p, 0xDEADBEEFu);
+            AssertEqual(rpp::readLEU32(p), 0xDEADBEEFu);
+
+            rpp::writeBEU64(p, 0x0102030405060708ull);
+            AssertEqual(rpp::readBEU64(p), 0x0102030405060708ull);
+        }
+    }
+};


### PR DESCRIPTION
The `readBEU*` / `writeBEU*` / `readLEU*` / `writeLEU*` helpers do `*reinterpret_cast<T*>(ptr)`. That's undefined behaviour whenever `ptr` isn't aligned to `T`, which comes up a lot in practice — anything writing packed fields at odd byte offsets in a buffer hits it. On x86 it usually works by luck, but on strict-alignment chips (ARM, AVR32) it can fault or return junk, and UBSan flags it.

This routes the load/store through `memcpy`, which is well-defined at any alignment. On platforms that allow unaligned access the compiler folds the `memcpy` + byteswap straight back into a single load/store with a bswap, so there's no runtime cost — same codegen as before on x86/x64, just correct everywhere.

Added `tests/test_endian.cpp` covering byte order, roundtrips, and specifically the unaligned-offset case (offsets 1–7) for all twelve helpers. README line refs updated via `update_doc_linerefs.py`.

Where this came from: krattlink's RTP header packing writes 16/32-bit fields at offsets like `buf+1` and `buf+3`. We'd just removed unaligned reads there for UBSan, so we couldn't reuse these helpers without reintroducing the same UB — hence the local byte-wise copies. With this change we can drop those and consolidate onto the shared rpp ones.

Verified with `CXX20=1 mama gcc tsan build clang-tidy test`: `test_endian` passes 4/4 under TSAN and clang-tidy is clean. (The full suite has some pre-existing races in `test_semaphore` / `test_future` coroutine paths — untouched here and unrelated to this header-only change.)
