### PR TITLE
sockets: skip NULL ifa_addr entries in get_interfaces instead of stopping 

### DIFF
--- a/src/rpp/sockets.cpp
+++ b/src/rpp/sockets.cpp
@@ -641,14 +641,14 @@ namespace rpp
         if (!getifaddrs(&if_addrs))
         {
             int count = 0;
-            for (auto* ifa = if_addrs; (ifa && ifa->ifa_addr); ifa = ifa->ifa_next) {
-                if (!family || ifa->ifa_addr->sa_family == family) ++count;
+            for (auto* ifa = if_addrs; ifa; ifa = ifa->ifa_next) {
+                if (ifa->ifa_addr && (!family || ifa->ifa_addr->sa_family == family)) ++count;
             }
             out.reserve(count);
 
-            for (auto* ifa = if_addrs; (ifa && ifa->ifa_addr); ifa = ifa->ifa_next)
+            for (auto* ifa = if_addrs; ifa; ifa = ifa->ifa_next)
             {
-                if (!family || ifa->ifa_addr->sa_family == family)
+                if (ifa->ifa_addr && (!family || ifa->ifa_addr->sa_family == family))
                 {
                     ipinterface& in = out.emplace_back();
                     in.name = std::string{ifa->ifa_name};
@@ -2287,4 +2287,3 @@ namespace rpp
     ////////////////////////////////////////////////////////////////////////////////
 
 } // namespace rpp
-


### PR DESCRIPTION
getifaddrs may return entries with ifa_addr==NULL, for example a MAC-less TUN like tailscale0 or wireguard. The loop used `ifa->ifa_addr` as its continuation condition, so enumeration stopped at the first such entry returning an empty list.