### PR TITLE
fix/wide-string-corruption

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,21 @@ jobs:
       - run: make configure-cmake
       - run: CXX20=1 pipenv run mama mips verbose build jobs=3
   consumer-integration:
-    description: Build ReCpp as another project builds it, as a dependency and not the root
+    parameters:
+      compiler:
+        type: enum
+        enum: ["clang", "gcc"]
+        default: "gcc"
+        description: "Compiler the consumer builds ReCpp with"
+      cc_version:
+        type: string
+        default: "gcc-14"
+        description: "Compiler version. It must clear the modules minimum, gcc-14 or clang-21"
+      llvm_apt:
+        type: boolean
+        default: false
+        description: "Register apt.llvm.org, for a clang release the CI image does not carry"
+    description: Build ReCpp with << parameters.cc_version >> as another project builds it, as a dependency and not the root
     resource_class: medium+ # medium+: 3 CPU-s, 6GB RAM, large: 4 CPU-s, 8GB RAM
     docker:
       - image: cimg/python:3.14
@@ -149,22 +163,63 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt -y --allow-unauthenticated install libdw-dev libunwind-dev ninja-build
       - run: pipenv install mama
-      # gcc-14 plus Ninja is the configuration that turns modules on by itself, so this
+      - when:
+          condition: << parameters.llvm_apt >>
+          steps:
+            - run:
+                name: Register apt.llvm.org for << parameters.cc_version >>
+                command: |
+                  LLVM_VER=$(echo "<< parameters.cc_version >>" | cut -d- -f2)
+                  wget -qO llvm.sh https://apt.llvm.org/llvm.sh
+                  chmod +x llvm.sh
+                  sudo ./llvm.sh $LLVM_VER
+                  # CMake scans module dependencies with clang-scan-deps, which ships in
+                  # clang-tools. Without it a modules build configures and then fails.
+                  sudo apt-get install -y clang-tools-$LLVM_VER
+      # Ninja plus a compiler over the modules minimum turns modules on by itself, so this
       # job builds ReCpp with modules the way a downstream project builds it.
-      - run: pipenv run mama install-gcc-14
+      - run: pipenv run mama install-<< parameters.cc_version >>
       - run: make configure-cmake
       - run:
-          name: Build and run the consumer
+          name: Build and run the consumer with << parameters.cc_version >>
           command: |
             # the Pipfile lives at the repo root, and the consumer builds one level down
             export PIPENV_PIPFILE=$(pwd)/Pipfile
             cd tests/consumer
             # ninja reads the affinity mask, and it ignores the jobs= mama passes to make
-            CXX20=1 taskset -c 0-2 pipenv run mama gcc verbose build test jobs=3 2>&1 | tee build.log
+            CXX20=1 taskset -c 0-2 pipenv run mama << parameters.compiler >> verbose build test jobs=3 2>&1 | tee build.log
             # AUTO turns modules off and keeps going, so without this the job would still pass
             # if ReCpp stopped enabling modules when another project builds it
             grep -q "C++20 Modules enabled" build.log \
               || { echo "FAIL: ReCpp built no modules as a dependency"; grep -i "MODULES" build.log; exit 1; }
+  consumer-integration-msvc:
+    description: Build ReCpp with MSVC as another project builds it, as a dependency and not the root
+    executor:
+      name: win/default
+      size: medium # can be medium(4 CPU), large, xlarge, 2xlarge
+    steps:
+      - checkout
+      - run: pip3 install mama
+      - run: choco install cmake -y
+      - run:
+          name: Build and run the consumer
+          command: |
+              $env:Path+=";$Env:ProgramFiles\CMake\bin";
+              $env:CXX20="1";
+              cd tests/consumer
+              # a bare cmake message() writes to stderr, so the log needs 2>&1 to catch the
+              # modules line, and Continue keeps those lines from aborting the step
+              $ErrorActionPreference = 'Continue'
+              # mama picks a Visual Studio generator, and CMake scans modules on that one too
+              mama windows verbose build test jobs=4 2>&1 | Tee-Object -FilePath build.log
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+              # AUTO turns modules off and keeps going, so without this the job would still pass
+              # if ReCpp stopped enabling modules when another project builds it
+              if (-not (Select-String -Path build.log -Pattern 'C\+\+20 Modules enabled' -Quiet)) {
+                  Write-Host "FAIL: ReCpp built no modules as a dependency"
+                  Select-String -Path build.log -Pattern 'MODULES'
+                  exit 1
+              }
   android-build:
     parameters:
       docker_image:
@@ -292,8 +347,18 @@ workflows:
           no_ninja: ""
           build_with_modules: "ON"
           llvm_apt: true
-      # Integration: ReCpp as somebody else's dependency
-      - consumer-integration
+      # Integration: ReCpp as somebody else's dependency, on all three compiler families
+      - consumer-integration:
+          name: consumer-integration
+          compiler: gcc
+          cc_version: gcc-14
+      - consumer-integration:
+          name: consumer-clang21
+          compiler: clang
+          cc_version: clang-21
+          llvm_apt: true
+      - consumer-integration-msvc:
+          name: consumer-msvc2022
       # Other platform builds
       - win64-cpp20-msvc2022
       - mipsel-cpp20-gcc12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,10 @@ jobs:
         type: boolean
         default: false
         description: "Register apt.llvm.org, for a clang release the CI image does not carry"
+      mama_flags:
+        type: string
+        default: ""
+        description: "Extra mama flags. clang needs nocache, see BUGS.md B11"
     description: Build ReCpp with << parameters.cc_version >> as another project builds it, as a dependency and not the root
     resource_class: medium+ # medium+: 3 CPU-s, 6GB RAM, large: 4 CPU-s, 8GB RAM
     docker:
@@ -192,7 +196,7 @@ jobs:
             export PIPENV_PIPFILE=$(pwd)/Pipfile
             cd tests/consumer
             # ninja reads the affinity mask, and it ignores the jobs= mama passes to make
-            CXX20=1 taskset -c 0-2 pipenv run mama << parameters.compiler >> verbose build test jobs=3 2>&1 | tee build.log
+            CXX20=1 taskset -c 0-2 pipenv run mama << parameters.compiler >> << parameters.mama_flags >> verbose build test jobs=3 2>&1 | tee build.log
             # AUTO turns modules off and keeps going, so without this the job would still pass
             # if ReCpp stopped enabling modules when another project builds it
             # AUTO turns modules off and keeps going, so without this the job would still pass
@@ -374,6 +378,9 @@ workflows:
           compiler: clang
           cc_version: clang-21
           llvm_apt: true
+          # the compiler-seed cache skips the step that finds clang-scan-deps, so a
+          # dependency build reports no scan-deps and drops modules. BUGS.md B11
+          mama_flags: "nocache"
       - consumer-integration-msvc:
           name: consumer-msvc2022
       # Other platform builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,11 @@ jobs:
                   # CMake scans module dependencies with clang-scan-deps, which ships in
                   # clang-tools. Without it a modules build configures and then fails.
                   sudo apt-get install -y clang-tools-$LLVM_VER
+                  # CMake also accepts the unversioned name, so alias it the way mama aliases clang
+                  sudo update-alternatives --install /usr/bin/clang-scan-deps clang-scan-deps \
+                                           /usr/bin/clang-scan-deps-$LLVM_VER 100
+                  # fail here, where the cause is obvious, instead of at the modules check later
+                  clang-scan-deps --version
       # Ninja plus a compiler over the modules minimum turns modules on by itself, so this
       # job builds ReCpp with modules the way a downstream project builds it.
       - run: pipenv run mama install-<< parameters.cc_version >>
@@ -190,8 +195,20 @@ jobs:
             CXX20=1 taskset -c 0-2 pipenv run mama << parameters.compiler >> verbose build test jobs=3 2>&1 | tee build.log
             # AUTO turns modules off and keeps going, so without this the job would still pass
             # if ReCpp stopped enabling modules when another project builds it
-            grep -q "C++20 Modules enabled" build.log \
-              || { echo "FAIL: ReCpp built no modules as a dependency"; grep -i "MODULES" build.log; exit 1; }
+            # AUTO turns modules off and keeps going, so without this the job would still pass
+            # if ReCpp stopped enabling modules when another project builds it
+            if ! grep -q "C++20 Modules enabled" build.log; then
+              echo "FAIL: ReCpp built no modules as a dependency"
+              grep -i "MODULES" build.log
+              # a missing binary blames this job, a set binary with an empty cache entry blames
+              # the build tool, which configures a dependency differently from a root target
+              echo "--- clang-scan-deps on this box ---"
+              ls -la /usr/bin/clang-scan-deps* /usr/lib/llvm-*/bin/clang-scan-deps 2>&1 | head
+              echo "--- what cmake resolved for the ReCpp dependency ---"
+              find .. -name CMakeCache.txt -path "*ReCpp*" \
+                   -exec grep -H "CMAKE_CXX_COMPILER:\|CLANG_SCAN_DEPS" {} \; 2>/dev/null | head
+              exit 1
+            fi
   consumer-integration-msvc:
     description: Build ReCpp with MSVC as another project builds it, as a dependency and not the root
     executor:

--- a/BUGS.md
+++ b/BUGS.md
@@ -26,38 +26,6 @@ Nothing joins that teardown, so no consumer can know the frame is gone.
 Worked around in the test: `test_semaphore` waits for `active_tasks()` to reach 0
 between cases. The library ordering is unchanged and still unsynchronized.
 
-### B7. `num_physical_cores()` reports host cores inside a container
-`std::thread::hardware_concurrency()` answers for the host, not for the cores a
-container may use, so the thread pool oversubscribes. On a 3 CPU CircleCI
-container it sized the pool to 8, and `parallel_for` ran 1.46x slower than the
-serial loop, which failed `test_threadpool.cpp:239`.
-`threads.cpp:169` already carries a `CIRCLECI` mitigation, and it sits inside the
-`MIPS || RASPI || YOCTO_LINUX || RPP_ANDROID` branch, so no x86 build reaches it.
-Fixed: `max_usable_cores()` in `threads.cpp` reads the cgroup quota, v2 `cpu.max`
-then v1 `cpu.cfs_quota_us`, and falls back to the affinity mask.
-`num_physical_cores()` never reports more than that. Linux covers Android and
-Yocto. Windows reads the process affinity mask. macOS and iOS cap nothing.
-The `CIRCLECI` guess that divided by 4 is gone.
-Verified: `taskset -c 0` gives 1 core where the machine reports 4.
-The test also skips the parallel-against-serial bound when `CIRCLECI` is set,
-because a shared runner cannot measure that ratio.
-Tracked: https://github.com/RedFox20/ReCpp/issues/60
-
-### B8. `pump_until_ready_times_out_without_blocking` aborted on Windows
-The job printed the test name and `Exited with code exit status 1`, with no
-assertion text, so the process died instead of failing an assertion. Not
-reproduced on Linux, and CircleCI logs are not reachable from the dev container.
-Cause unknown. `~event_loop()` calls `std::terminate()` when a thread other than
-the owner destroys it, which matches an exit with no output, but nothing proves
-that path ran.
-Hardened, not fixed: the test prints `ready` and the elapsed before it asserts,
-drains with the non-throwing `pump_until_ready` instead of `run_until_ready`, and
-waits for `has_background_tasks()` to clear. The old drain threw on timeout, and
-unwinding left a pool task mid-sleep with a continuation into a loop that the next
-`TestCaseSetup()` destroys.
-Next Windows failure should print the diagnostic line first. That names which half
-of the test died.
-
 ### B1. TSAN races reproduce only under CPU load, cause unknown
 Two sites, both seen in one loaded sweep of 33 sequential runs, 4 reports:
 - `thread_pool.cpp:351`, a pool worker writing in the `catch` handler against a
@@ -131,6 +99,40 @@ inside `DbgAssert`, not the `#define LogError` at line 128. Corrected by hand.
 The script's own docstring already warns that it has mistakes.
 
 ## Closed
+
+### C14. `num_physical_cores()` reported host cores inside a container
+`std::thread::hardware_concurrency()` answers for the host, not for the cores a
+container may use, so the thread pool oversubscribes. On a 3 CPU CircleCI
+container it sized the pool to 8, and `parallel_for` ran 1.46x slower than the
+serial loop, which failed `test_threadpool.cpp:239`.
+`threads.cpp:169` already carries a `CIRCLECI` mitigation, and it sits inside the
+`MIPS || RASPI || YOCTO_LINUX || RPP_ANDROID` branch, so no x86 build reaches it.
+Fixed: `max_usable_cores()` in `threads.cpp` reads the cgroup quota, v2 `cpu.max`
+then v1 `cpu.cfs_quota_us`, and falls back to the affinity mask.
+`num_physical_cores()` never reports more than that. Linux covers Android and
+Yocto. Windows reads the process affinity mask. macOS and iOS cap nothing.
+The `CIRCLECI` guess that divided by 4 is gone.
+Verified: `taskset -c 0` gives 1 core where the machine reports 4.
+The test also skips the parallel-against-serial bound when `CIRCLECI` is set,
+because a shared runner cannot measure that ratio.
+Tracked: https://github.com/RedFox20/ReCpp/issues/60
+
+### C13. `pump_until_ready_times_out_without_blocking` aborted on Windows
+The job printed the test name and `Exited with code exit status 1`, with no
+assertion text, so the process died instead of failing an assertion. Not
+reproduced on Linux, and CircleCI logs are not reachable from the dev container.
+Cause unknown. `~event_loop()` calls `std::terminate()` when a thread other than
+the owner destroys it, which matches an exit with no output, but nothing proves
+that path ran.
+Hardened, not fixed: the test prints `ready` and the elapsed before it asserts,
+drains with the non-throwing `pump_until_ready` instead of `run_until_ready`, and
+waits for `has_background_tasks()` to clear. The old drain threw on timeout, and
+unwinding left a pool task mid-sleep with a continuation into a loop that the next
+`TestCaseSetup()` destroys.
+Next Windows failure should print the diagnostic line first. That names which half
+of the test died.
+All 27 CI jobs pass on the merge, Windows included, so the abort is gone.
+The root cause was never proven. Reopen with the printed diagnostic if it returns.
 
 ### C12. Every Windows thread name read back as "true"
 `get_thread_name()` passed a `PWSTR` to `rpp::to_string()`. MSVC keeps `wchar_t`

--- a/BUGS.md
+++ b/BUGS.md
@@ -113,6 +113,29 @@ lost 3 jobs of 27. That sample is small, but at that rate an all-green board is
 rare, near 1 run in 20. A PR that cannot show green teaches the reader to ignore
 a red job, which is the real cost and the argument for the slack policy above.
 
+Two CI logs name the assertions, and both belong to this tail:
+
+- `test_concurrent_queue.cpp:411`, `wait_pop_until`, elapsed 12.56 ms against a
+  10.0 ms upper bound, on an Android job.
+- `test_semaphore.cpp:184`, `can_notify_worker_thread_sub_millisecond`, 465
+  notifies counted of 500 sent, on gcc-14.
+
+The semaphore one was not a bound at all. It repeats the defect this list already
+fixed at `test_semaphore.cpp:132`, because the sibling test never got that fix. It
+waited a fixed 5000 us instead of waiting for the count, so a slow worker lost
+whatever it had not drained. Both tests call `drain_notifies()` now.
+
+The Android job also narrows the open item. That job runs clang-tidy, not a
+sanitizer, so a multiplier keyed on `RPP_ASAN` or the TSAN equivalent would not
+have caught it. A loaded machine is enough. The policy has to widen an upper bound
+by load, not by sanitizer.
+
+The tail reproduces locally, which the entry above assumed it did not. A
+`clang-tidy` build lost `test_concurrent_queue.cpp:447` at 18.196 ms against an
+18.0 ms bound, and `test_sockets.cpp:398` cascaded 8 assertions from one missed
+`pollin`. Three plain runs of the same binary passed 501/501. So the slack policy
+can prove itself on a loaded machine, without waiting for CI.
+
 ### B3. mamabuild cannot export C++20 modules
 `mamafile.py` `package()` exports `.h` and `.natvis` only, so no `.cppm` reaches
 a consumer. `CMakeLists.txt` has no `install(TARGETS ... FILE_SET CXX_MODULES)`.

--- a/BUGS.md
+++ b/BUGS.md
@@ -97,6 +97,16 @@ the assertion needs. The semaphore one was different: the producer set
 `working = false` while the worker still had notifies to drain, so it now waits for
 the count first.
 
+The tail also reaches CI, and it hides behind a code change. Commit `3f6457d`
+failed `ubuntu-cpp20-tsan-clang18`, `ubuntu-cpp20-asan-gcc13` and
+`android-cpp20-r29-ninja`, while the parent commit passed all 27 jobs. The commit
+changed no machine code: an `-O2` disassembly of `sprint.cpp` from each commit
+differs in 0 instructions, because the edit only moves a declaration behind
+`#if RPP_WCHAR_IS_UTF32`, which stays 1 on both platforms. The C++23 twin of each
+failing job passed, and `gcc asan` C++20 passed locally at 501/501. So the three
+failures are this tail, not the commit. A red job after an inert change costs more
+time than the flake itself, which is the argument for the slack policy above.
+
 ### B3. mamabuild cannot export C++20 modules
 `mamafile.py` `package()` exports `.h` and `.natvis` only, so no `.cppm` reaches
 a consumer. `CMakeLists.txt` has no `install(TARGETS ... FILE_SET CXX_MODULES)`.

--- a/BUGS.md
+++ b/BUGS.md
@@ -102,10 +102,16 @@ failed `ubuntu-cpp20-tsan-clang18`, `ubuntu-cpp20-asan-gcc13` and
 `android-cpp20-r29-ninja`, while the parent commit passed all 27 jobs. The commit
 changed no machine code: an `-O2` disassembly of `sprint.cpp` from each commit
 differs in 0 instructions, because the edit only moves a declaration behind
-`#if RPP_WCHAR_IS_UTF32`, which stays 1 on both platforms. The C++23 twin of each
-failing job passed, and `gcc asan` C++20 passed locally at 501/501. So the three
-failures are this tail, not the commit. A red job after an inert change costs more
-time than the flake itself, which is the argument for the slack policy above.
+`#if RPP_WCHAR_IS_UTF32`, which stays 1 on both platforms.
+
+The next commit settled it. `b82a690` edits this file and nothing else, and it
+failed `mipsel-cpp20-gcc12`, `ubuntu-cpp26-asan-gcc14` and
+`android-cpp20-r27-clang-tidy-clang18`. All three passed on `3f6457d`, and all
+three earlier failures passed here. A markdown edit cannot break a mipsel build,
+so the failing set is random and it does not depend on the code. Two runs each
+lost 3 jobs of 27. That sample is small, but at that rate an all-green board is
+rare, near 1 run in 20. A PR that cannot show green teaches the reader to ignore
+a red job, which is the real cost and the argument for the slack policy above.
 
 ### B3. mamabuild cannot export C++20 modules
 `mamafile.py` `package()` exports `.h` and `.natvis` only, so no `.cppm` reaches

--- a/BUGS.md
+++ b/BUGS.md
@@ -13,18 +13,25 @@ a dependency build, which is where C11 broke KrattGCS.
 The owner chose to keep AUTO as the default, so this stays open until B3 lands and
 makes the modules reachable. Until then a consumer pays the build cost for nothing.
 
-### B9. A pool thread tears down a coroutine frame after `.get()` returned
-TSAN, `test_semaphore::co_await_semaphore_already_signaled`, on clang-18:
-`operator delete` from `~promise()` on `rpp_task_20`, against a main-thread read
-of the same address. The trace names `test_co_await_semaphore_timeout`, which is
-the **previous** test case.
-`semaphore::co_await_handle::await_suspend` posts the resume to a detached pool
-task. That task sets the promise, which releases `.get()`, and only then destroys
-the coroutine frame. The main thread runs the next case while the pool thread is
-still freeing, and the allocator hands the same address out again.
-Nothing joins that teardown, so no consumer can know the frame is gone.
-Worked around in the test: `test_semaphore` waits for `active_tasks()` to reach 0
-between cases. The library ordering is unchanged and still unsynchronized.
+### B9. A detached pool task frees its promise after the test that made it ended
+Two TSAN reports from CI on clang-18, both the same shape: `operator delete` from
+`~promise()` on a pool worker, against the main thread in `pthread_cond_wait`
+inside `run_test_func`.
+The thread-creation stack names the culprit each time, and it is always an
+**earlier** test:
+- a task from `test_close_sync.cpp:29` freed during `test_concurrent_queue`
+- a task from `test_future.cpp:103` freed during a later `test_future` case
+
+`async_task`, `cfuture::then()` and `semaphore::co_await_handle::await_suspend`
+all post through `parallel_task_detached`. The task owns the promise, and nothing
+joins it, so it destroys the promise long after `.get()` released the waiter.
+Fixed in the test framework, which is where CLAUDE.md puts a test-only race:
+`run_test_func` now waits for `thread_pool::global().active_tasks()` to reach 0
+after every case, and it prints a warning when a case leaves work running.
+Verified that the signal is live: `active_tasks()` reads 1 while a detached task
+sleeps, and the drain returns the moment it reaches 0.
+The library ordering is unchanged. A consumer that detaches a task still owns the
+lifetime problem, so this stays open until `async_task` offers a join.
 
 ### B10. A test handed the event_loop a pool that dies before the loop
 `test_event_loop::custom_thread_pool` built a **local** `rpp::thread_pool` and gave

--- a/BUGS.md
+++ b/BUGS.md
@@ -26,6 +26,17 @@ Nothing joins that teardown, so no consumer can know the frame is gone.
 Worked around in the test: `test_semaphore` waits for `active_tasks()` to reach 0
 between cases. The library ordering is unchanged and still unsynchronized.
 
+### B10. A test handed the event_loop a pool that dies before the loop
+`test_event_loop::custom_thread_pool` built a **local** `rpp::thread_pool` and gave
+the loop a raw pointer to it. The case returns, the local pool dies, and only then
+does `TestCaseCleanup()` destroy the loop, so the loop outlives the pool it points
+at. Android caught it in CI:
+`FORTIFY: pthread_mutex_trylock called on a destroyed mutex`, then `SIGABRT` on
+`rpp_task_13`, during the next case.
+Fixed: the pool is a fixture member now, and cleanup destroys the loop first.
+The same shape can hit any consumer that gives `event_loop` a pool with a shorter
+life. `event_loop` takes a raw `thread_pool*` and documents no lifetime rule.
+
 ### B1. TSAN races reproduce only under CPU load, cause unknown
 Two sites, both seen in one loaded sweep of 33 sequential runs, 4 reports:
 - `thread_pool.cpp:351`, a pool worker writing in the `catch` handler against a

--- a/BUGS.md
+++ b/BUGS.md
@@ -6,6 +6,17 @@ lines.
 
 ## Open
 
+### B11. mama's compiler-seed cache drops clang-scan-deps, so a dependency build loses modules
+Not a ReCpp defect. `consumer-clang21` builds ReCpp as a dependency, and it reported
+`the Clang toolchain ships no clang-scan-deps` while all three copies of the binary sat
+on the box, one of them beside the compiler. `CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS` was
+absent from `CMakeCache.txt`, not `NOTFOUND`, so the `find_program` never ran.
+`Compiler/Clang-FindBinUtils.cmake` runs only from `CMakeDetermineCXXCompiler.cmake:203`,
+which CMake skips when `CMakeCXXCompiler.cmake` already exists. mama seeds that exact
+file, and the log shows `seed[RppConsumer] ... hit -> use` with `Configuring done (0.0s)`.
+The seed replays 5 cache keys and none of the 3 that module scanning needs.
+The job passes `nocache` until mama replays them. Reported to mamabuild.
+
 ### B6. A consumer builds modules that no consumer can import
 `package()` exports `.h` and `.natvis` only, so a downstream project compiles two
 BMIs and then cannot `import` either one. See B3. AUTO still turns modules on in

--- a/README.md
+++ b/README.md
@@ -278,16 +278,16 @@ Platform detection, compiler macros, and base type definitions. This is the foun
 
 | Macro | Description |
 |-------|-------------|
-| [`RPP_BARE_METAL`](src/rpp/config.h#L188) | `1` if targeting a bare-metal/embedded platform (FreeRTOS or STM32 HAL) |
-| [`RPP_FREERTOS`](src/rpp/config.h#L176) | `1` if targeting FreeRTOS |
-| [`RPP_STM32_HAL`](src/rpp/config.h#L180) | `1` if targeting STM32 HAL (requires `RPP_STM32_HAL_H` path) |
-| [`RPP_USE_EYALROZ_PRINTF`](src/rpp/config.h#L194) | `1` to use [eyalroz/printf](https://github.com/eyalroz/printf) (`printf_`/`snprintf_`) on bare-metal instead of standard `printf` |
-| [`RPP_CORTEX_M_ARCH`](src/rpp/config.h#L199) | `1` if targeting ARM Cortex-M architecture |
-| [`RPP_ARM_ARCH`](src/rpp/config.h#L215) | `1` if compiling for ARM (`__thumb__` or `__arm__`) |
-| [`RPP_64BIT`](src/rpp/config.h#L240) | `1` if compiling for a 64-bit target |
-| [`RPP_LITTLE_ENDIAN`](src/rpp/config.h#L392) | `1` if target is little-endian |
-| [`RPP_BIG_ENDIAN`](src/rpp/config.h#L400) | `1` if target is big-endian |
-| [`RPP_HAS_EXCEPTIONS`](src/rpp/config.h#L410) | `1` if C++ exceptions are enabled. Auto-detected via `_CPPUNWIND` (MSVC), `__EXCEPTIONS`/`__cpp_exceptions` (GCC/Clang). Defaults to `1` on unknown compilers. Can be overridden manually. |
+| [`RPP_BARE_METAL`](src/rpp/config.h#L199) | `1` if targeting a bare-metal/embedded platform (FreeRTOS or STM32 HAL) |
+| [`RPP_FREERTOS`](src/rpp/config.h#L187) | `1` if targeting FreeRTOS |
+| [`RPP_STM32_HAL`](src/rpp/config.h#L191) | `1` if targeting STM32 HAL (requires `RPP_STM32_HAL_H` path) |
+| [`RPP_USE_EYALROZ_PRINTF`](src/rpp/config.h#L205) | `1` to use [eyalroz/printf](https://github.com/eyalroz/printf) (`printf_`/`snprintf_`) on bare-metal instead of standard `printf` |
+| [`RPP_CORTEX_M_ARCH`](src/rpp/config.h#L210) | `1` if targeting ARM Cortex-M architecture |
+| [`RPP_ARM_ARCH`](src/rpp/config.h#L226) | `1` if compiling for ARM (`__thumb__` or `__arm__`) |
+| [`RPP_64BIT`](src/rpp/config.h#L251) | `1` if compiling for a 64-bit target |
+| [`RPP_LITTLE_ENDIAN`](src/rpp/config.h#L403) | `1` if target is little-endian |
+| [`RPP_BIG_ENDIAN`](src/rpp/config.h#L411) | `1` if target is big-endian |
+| [`RPP_HAS_EXCEPTIONS`](src/rpp/config.h#L421) | `1` if C++ exceptions are enabled. Auto-detected via `_CPPUNWIND` (MSVC), `__EXCEPTIONS`/`__cpp_exceptions` (GCC/Clang). Defaults to `1` on unknown compilers. Can be overridden manually. |
 
 ### Feature Detection
 
@@ -295,64 +295,65 @@ Platform detection, compiler macros, and base type definitions. This is the foun
 |-------|-------------|
 | [`RPP_HAS_QT`](src/rpp/config.h#L157) | `1` if Qt framework is detected (`QT_VERSION` or `QT_CORE_LIB`) |
 | [`RPP_ENABLE_UNICODE`](src/rpp/config.h#L167) | `1` if UTF-16/wstring support is enabled (auto-detected per platform) |
+| [`RPP_WCHAR_IS_UTF32`](src/rpp/config.h#L180) | `1` if a `wchar_t` holds a whole UTF-32 code point, `0` if it holds UTF-16 (Windows) |
 
 ### Function Attributes
 
 | Macro | Description |
 |-------|-------------|
-| [`FINLINE`](src/rpp/config.h#L233) | Force inline: `__forceinline` on MSVC, `__attribute__((always_inline))` on GCC/Clang |
-| [`NOINLINE`](src/rpp/config.h#L224) | Prevent inlining: `__declspec(noinline)` on MSVC, `__attribute__((noinline))` on GCC/Clang |
-| [`NODISCARD`](src/rpp/config.h#L266) | Portable `[[nodiscard]]` with fallback to empty on older compilers |
-| [`RPP_NORETURN`](src/rpp/config.h#L325) | Portable `[[noreturn]]` / `__declspec(noreturn)` / `__attribute__((noreturn))` |
-| [`NOCOPY_NOMOVE(T)`](src/rpp/config.h#L257) | Delete copy and move constructors and assignment operators |
+| [`FINLINE`](src/rpp/config.h#L244) | Force inline: `__forceinline` on MSVC, `__attribute__((always_inline))` on GCC/Clang |
+| [`NOINLINE`](src/rpp/config.h#L235) | Prevent inlining: `__declspec(noinline)` on MSVC, `__attribute__((noinline))` on GCC/Clang |
+| [`NODISCARD`](src/rpp/config.h#L277) | Portable `[[nodiscard]]` with fallback to empty on older compilers |
+| [`RPP_NORETURN`](src/rpp/config.h#L336) | Portable `[[noreturn]]` / `__declspec(noreturn)` / `__attribute__((noreturn))` |
+| [`NOCOPY_NOMOVE(T)`](src/rpp/config.h#L268) | Delete copy and move constructors and assignment operators |
 
 ### Printf Format Validation
 
 | Macro | Description |
 |-------|-------------|
-| [`PRINTF_FMTSTR`](src/rpp/config.h#L289) | MSVC `_Printf_format_string_` annotation (empty on GCC/Clang) |
-| [`PRINTF_CHECKFMT1..8`](src/rpp/config.h#L300) | GCC/Clang `__format__(__printf__)` attribute for validating printf args at compile time. Number indicates format string argument position |
+| [`PRINTF_FMTSTR`](src/rpp/config.h#L300) | MSVC `_Printf_format_string_` annotation (empty on GCC/Clang) |
+| [`PRINTF_CHECKFMT1..8`](src/rpp/config.h#L311) | GCC/Clang `__format__(__printf__)` attribute for validating printf args at compile time. Number indicates format string argument position |
 
 ### Lifetime & Coroutine Annotations
 
 | Macro | Description |
 |-------|-------------|
-| [`RPP_LIFETIMEBOUND`](src/rpp/config.h#L340) | Annotates parameters whose lifetime must outlive the return value. `[[msvc::lifetimebound]]` / `[[clang::lifetimebound]]` |
-| [`RPP_CORO_RETURN_TYPE`](src/rpp/config.h#L356) | Marks a type as a coroutine return type (`[[clang::coro_return_type]]`) |
-| [`RPP_CORO_WRAPPER`](src/rpp/config.h#L357) | Marks a non-coroutine function that returns a CRT (`[[clang::coro_wrapper]]`) |
-| [`RPP_CORO_LIFETIMEBOUND`](src/rpp/config.h#L358) | Coroutine-specific lifetime annotation (`[[clang::coro_lifetimebound]]`) |
+| [`RPP_LIFETIMEBOUND`](src/rpp/config.h#L351) | Annotates parameters whose lifetime must outlive the return value. `[[msvc::lifetimebound]]` / `[[clang::lifetimebound]]` |
+| [`RPP_CORO_RETURN_TYPE`](src/rpp/config.h#L367) | Marks a type as a coroutine return type (`[[clang::coro_return_type]]`) |
+| [`RPP_CORO_WRAPPER`](src/rpp/config.h#L368) | Marks a non-coroutine function that returns a CRT (`[[clang::coro_wrapper]]`) |
+| [`RPP_CORO_LIFETIMEBOUND`](src/rpp/config.h#L369) | Coroutine-specific lifetime annotation (`[[clang::coro_lifetimebound]]`) |
 
 ### Integer Size Constants
 
 | Macro | Description |
 |-------|-------------|
-| [`RPP_SHORT_SIZE`](src/rpp/config.h#L369) | Size of `short` in bytes (platform-dependent) |
-| [`RPP_INT_SIZE`](src/rpp/config.h#L370) | Size of `int` in bytes |
-| [`RPP_LONG_SIZE`](src/rpp/config.h#L371) | Size of `long` in bytes |
-| [`RPP_LONG_LONG_SIZE`](src/rpp/config.h#L372) | Size of `long long` in bytes |
-| [`RPP_INT64_MIN`](src/rpp/config.h#L381) | 64-bit signed integer limits |
-| [`RPP_INT64_MAX`](src/rpp/config.h#L380) | 64-bit signed integer limits |
-| [`RPP_UINT64_MIN`](src/rpp/config.h#L383) | 64-bit unsigned integer limits |
-| [`RPP_UINT64_MAX`](src/rpp/config.h#L382) | 64-bit unsigned integer limits |
-| [`RPP_INT32_MIN`](src/rpp/config.h#L385) | 32-bit signed integer limits |
-| [`RPP_INT32_MAX`](src/rpp/config.h#L384) | 32-bit signed integer limits |
-| [`RPP_UINT32_MIN`](src/rpp/config.h#L387) | 32-bit unsigned integer limits |
-| [`RPP_UINT32_MAX`](src/rpp/config.h#L386) | 32-bit unsigned integer limits |
+| [`RPP_SHORT_SIZE`](src/rpp/config.h#L380) | Size of `short` in bytes (platform-dependent) |
+| [`RPP_INT_SIZE`](src/rpp/config.h#L381) | Size of `int` in bytes |
+| [`RPP_LONG_SIZE`](src/rpp/config.h#L382) | Size of `long` in bytes |
+| [`RPP_LONG_LONG_SIZE`](src/rpp/config.h#L383) | Size of `long long` in bytes |
+| [`RPP_INT64_MIN`](src/rpp/config.h#L392) | 64-bit signed integer limits |
+| [`RPP_INT64_MAX`](src/rpp/config.h#L391) | 64-bit signed integer limits |
+| [`RPP_UINT64_MIN`](src/rpp/config.h#L394) | 64-bit unsigned integer limits |
+| [`RPP_UINT64_MAX`](src/rpp/config.h#L393) | 64-bit unsigned integer limits |
+| [`RPP_INT32_MIN`](src/rpp/config.h#L396) | 32-bit signed integer limits |
+| [`RPP_INT32_MAX`](src/rpp/config.h#L395) | 32-bit signed integer limits |
+| [`RPP_UINT32_MIN`](src/rpp/config.h#L398) | 32-bit unsigned integer limits |
+| [`RPP_UINT32_MAX`](src/rpp/config.h#L397) | 32-bit unsigned integer limits |
 
 ### C++ Type Aliases (namespace `rpp`)
 
 | Type | Description |
 |------|-------------|
-| [`byte`](src/rpp/config.h#L430) | `unsigned char` |
-| [`ushort`](src/rpp/config.h#L431) | `unsigned short` |
-| [`uint`](src/rpp/config.h#L432) | `unsigned int` |
-| [`ulong`](src/rpp/config.h#L433) | `unsigned long` |
-| [`int16`](src/rpp/config.h#L435) | `short` (16-bit signed) |
-| [`uint16`](src/rpp/config.h#L436) | `unsigned short` (16-bit unsigned) |
-| [`int32`](src/rpp/config.h#L439) | `int` or `long` depending on `RPP_INT_SIZE` (32-bit signed) |
-| [`uint32`](src/rpp/config.h#L440) | `unsigned int` or `unsigned long` (32-bit unsigned) |
-| [`int64`](src/rpp/config.h#L446) | `long long` (64-bit signed) |
-| [`uint64`](src/rpp/config.h#L447) | `unsigned long long` (64-bit unsigned) |
+| [`byte`](src/rpp/config.h#L441) | `unsigned char` |
+| [`ushort`](src/rpp/config.h#L442) | `unsigned short` |
+| [`uint`](src/rpp/config.h#L443) | `unsigned int` |
+| [`ulong`](src/rpp/config.h#L444) | `unsigned long` |
+| [`int16`](src/rpp/config.h#L446) | `short` (16-bit signed) |
+| [`uint16`](src/rpp/config.h#L447) | `unsigned short` (16-bit unsigned) |
+| [`int32`](src/rpp/config.h#L450) | `int` or `long` depending on `RPP_INT_SIZE` (32-bit signed) |
+| [`uint32`](src/rpp/config.h#L451) | `unsigned int` or `unsigned long` (32-bit unsigned) |
+| [`int64`](src/rpp/config.h#L457) | `long long` (64-bit signed) |
+| [`uint64`](src/rpp/config.h#L458) | `unsigned long long` (64-bit unsigned) |
 
 ---
 
@@ -705,11 +706,11 @@ Fast string building and type-safe formatting. `string_buffer` is an always-null
 | Method | Description |
 |--------|-------------|
 | [`write(const T& v)`](src/rpp/sprint.h#L124) | Write a value (auto-converts most types) |
-| [`writeln(const Args&... args)`](src/rpp/sprint.h#L351) | Write values followed by newline |
+| [`writeln(const Args&... args)`](src/rpp/sprint.h#L361) | Write values followed by newline |
 | [`writef(const char* format, ...)`](src/rpp/sprint.h#L122) | Printf-style formatted write |
-| [`write_hex(const void* data, int numBytes)`](src/rpp/sprint.h#L297) | Write data as hex string |
-| [`write_cont(const Container& c)`](src/rpp/sprint.h#L254) | Write container contents |
-| [`prettyprint(const T& value)`](src/rpp/sprint.h#L359) | Pretty-print a value |
+| [`write_hex(const void* data, int numBytes)`](src/rpp/sprint.h#L307) | Write data as hex string |
+| [`write_cont(const Container& c)`](src/rpp/sprint.h#L264) | Write container contents |
+| [`prettyprint(const T& value)`](src/rpp/sprint.h#L369) | Pretty-print a value |
 | [`clear()`](src/rpp/sprint.h#L113) | Clear the buffer |
 | [`reserve(int capacity)`](src/rpp/sprint.h#L114) | Reserve capacity |
 | [`resize(int size)`](src/rpp/sprint.h#L115) | Resize buffer |
@@ -725,9 +726,9 @@ Fast string building and type-safe formatting. `string_buffer` is an always-null
 | [`to_string(float)`](src/rpp/sprint.h#L50) | Locale-agnostic float to string |
 | [`to_string(double)`](src/rpp/sprint.h#L51) | Locale-agnostic double to string |
 | [`to_string(bool)`](src/rpp/sprint.h#L54) | Bool to `"true"` or `"false"` |
-| [`print(args...)`](src/rpp/sprint.h#L473) | Print to stdout |
-| [`println(args...)`](src/rpp/sprint.h#L493) | Print to stdout with newline |
-| [`to_hex_string(s, opt)`](src/rpp/sprint.h#L419) | Converts string bytes to hexadecimal representation |
+| [`print(args...)`](src/rpp/sprint.h#L483) | Print to stdout |
+| [`println(args...)`](src/rpp/sprint.h#L503) | Print to stdout with newline |
+| [`to_hex_string(s, opt)`](src/rpp/sprint.h#L429) | Converts string bytes to hexadecimal representation |
 
 ### Example: Basic String Building
 

--- a/README.md
+++ b/README.md
@@ -705,11 +705,11 @@ Fast string building and type-safe formatting. `string_buffer` is an always-null
 | Method | Description |
 |--------|-------------|
 | [`write(const T& v)`](src/rpp/sprint.h#L124) | Write a value (auto-converts most types) |
-| [`writeln(const Args&... args)`](src/rpp/sprint.h#L339) | Write values followed by newline |
+| [`writeln(const Args&... args)`](src/rpp/sprint.h#L351) | Write values followed by newline |
 | [`writef(const char* format, ...)`](src/rpp/sprint.h#L122) | Printf-style formatted write |
-| [`write_hex(const void* data, int numBytes)`](src/rpp/sprint.h#L285) | Write data as hex string |
-| [`write_cont(const Container& c)`](src/rpp/sprint.h#L264) | Write container contents |
-| [`prettyprint(const T& value)`](src/rpp/sprint.h#L347) | Pretty-print a value |
+| [`write_hex(const void* data, int numBytes)`](src/rpp/sprint.h#L297) | Write data as hex string |
+| [`write_cont(const Container& c)`](src/rpp/sprint.h#L254) | Write container contents |
+| [`prettyprint(const T& value)`](src/rpp/sprint.h#L359) | Pretty-print a value |
 | [`clear()`](src/rpp/sprint.h#L113) | Clear the buffer |
 | [`reserve(int capacity)`](src/rpp/sprint.h#L114) | Reserve capacity |
 | [`resize(int size)`](src/rpp/sprint.h#L115) | Resize buffer |
@@ -725,9 +725,9 @@ Fast string building and type-safe formatting. `string_buffer` is an always-null
 | [`to_string(float)`](src/rpp/sprint.h#L50) | Locale-agnostic float to string |
 | [`to_string(double)`](src/rpp/sprint.h#L51) | Locale-agnostic double to string |
 | [`to_string(bool)`](src/rpp/sprint.h#L54) | Bool to `"true"` or `"false"` |
-| [`print(args...)`](src/rpp/sprint.h#L461) | Print to stdout |
-| [`println(args...)`](src/rpp/sprint.h#L481) | Print to stdout with newline |
-| [`to_hex_string(s, opt)`](src/rpp/sprint.h#L407) | Converts string bytes to hexadecimal representation |
+| [`print(args...)`](src/rpp/sprint.h#L473) | Print to stdout |
+| [`println(args...)`](src/rpp/sprint.h#L493) | Print to stdout with newline |
+| [`to_hex_string(s, opt)`](src/rpp/sprint.h#L419) | Converts string bytes to hexadecimal representation |
 
 ### Example: Basic String Building
 

--- a/src/rpp/config.h
+++ b/src/rpp/config.h
@@ -182,6 +182,13 @@
 #    define RPP_WCHAR_IS_UTF32 1
 #  endif
 #endif
+#ifdef __cplusplus
+// Two branches above guess without asking the compiler: _WIN32, and the fallback for a
+// compiler that defines no __SIZEOF_WCHAR_T__. A wrong guess picks the wrong decoder and
+// corrupts the text, so stop the build instead.
+static_assert(RPP_WCHAR_IS_UTF32 == (sizeof(wchar_t) == 4),
+              "RPP_WCHAR_IS_UTF32 does not match wchar_t on this compiler");
+#endif
 
 #ifndef RPP_FREERTOS
 #  define RPP_FREERTOS 0

--- a/src/rpp/config.h
+++ b/src/rpp/config.h
@@ -172,6 +172,17 @@
 #  endif
 #endif
 
+/// @brief 1 when a wchar_t holds a whole UTF-32 code point, 0 when it holds UTF-16.
+/// The preprocessor cannot evaluate sizeof, so this reads the compiler macro instead.
+/// Windows defines no such macro and always uses a 16-bit wchar_t.
+#ifndef RPP_WCHAR_IS_UTF32
+#  if defined(_WIN32) || (defined(__SIZEOF_WCHAR_T__) && __SIZEOF_WCHAR_T__ == 2)
+#    define RPP_WCHAR_IS_UTF32 0
+#  else
+#    define RPP_WCHAR_IS_UTF32 1
+#  endif
+#endif
+
 #ifndef RPP_FREERTOS
 #  define RPP_FREERTOS 0
 #endif

--- a/src/rpp/config.h
+++ b/src/rpp/config.h
@@ -172,9 +172,7 @@
 #  endif
 #endif
 
-/// @brief 1 when a wchar_t holds a whole UTF-32 code point, 0 when it holds UTF-16.
-/// The preprocessor cannot evaluate sizeof, so this reads the compiler macro instead.
-/// Windows defines no such macro and always uses a 16-bit wchar_t.
+/// @brief 1 when a wchar_t holds UTF-32, 0 when it holds UTF-16.
 #ifndef RPP_WCHAR_IS_UTF32
 #  if defined(_WIN32) || (defined(__SIZEOF_WCHAR_T__) && __SIZEOF_WCHAR_T__ == 2)
 #    define RPP_WCHAR_IS_UTF32 0
@@ -183,9 +181,7 @@
 #  endif
 #endif
 #ifdef __cplusplus
-// Two branches above guess without asking the compiler: _WIN32, and the fallback for a
-// compiler that defines no __SIZEOF_WCHAR_T__. A wrong guess picks the wrong decoder and
-// corrupts the text, so stop the build instead.
+// _WIN32 and the fallback both guess, and a wrong guess corrupts the decoded text
 static_assert(RPP_WCHAR_IS_UTF32 == (sizeof(wchar_t) == 4),
               "RPP_WCHAR_IS_UTF32 does not match wchar_t on this compiler");
 #endif

--- a/src/rpp/sprint.cpp
+++ b/src/rpp/sprint.cpp
@@ -146,6 +146,39 @@ namespace rpp
     void string_buffer::write(double value) noexcept { reserve(48); len += _tostring(&ptr[len], value); }
 
 #if RPP_ENABLE_UNICODE
+    void string_buffer::write_codepoint(char32_t codepoint) noexcept
+    {
+        int char_size;
+        if      (codepoint <= 0x7F)   char_size = 1;
+        else if (codepoint <= 0x7FF)  char_size = 2;
+        else if (codepoint <= 0xFFFF) char_size = 3;
+        else                          char_size = 4;
+        reserve(char_size);
+
+        if (char_size == 1)
+        {
+            ptr[len++] = (static_cast<char>(codepoint));
+        }
+        else if (char_size == 2)
+        {
+            ptr[len++] = (static_cast<char>(0xC0 | (codepoint >> 6)));
+            ptr[len++] = (static_cast<char>(0x80 | (codepoint & 0x3F)));
+        }
+        else if (char_size == 3)
+        {
+            ptr[len++] = (static_cast<char>(0xE0 | (codepoint >> 12)));
+            ptr[len++] = (static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+            ptr[len++] = (static_cast<char>(0x80 | (codepoint & 0x3F)));
+        }
+        else
+        {
+            ptr[len++] = (static_cast<char>(0xF0 | (codepoint >> 18)));
+            ptr[len++] = (static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
+            ptr[len++] = (static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+            ptr[len++] = (static_cast<char>(0x80 | (codepoint & 0x3F)));
+        }
+    }
+
     void string_buffer::write_utf16_as_utf8(const char16_t* utf16, int utflength) noexcept
     {
         // if UTF-16 contains only ASCII, then UTF-8 will be the same length
@@ -162,38 +195,16 @@ namespace rpp
                 char32_t low = utf16[++i] - 0xDC00; // consume i+1 pair
                 codepoint = (high << 10) + low + 0x10000;
             }
-
-            // Convert to UTF-8
-            int char_size;
-            if      (codepoint <= 0x7F)   char_size = 1;
-            else if (codepoint <= 0x7FF)  char_size = 2;
-            else if (codepoint <= 0xFFFF) char_size = 3;
-            else                          char_size = 4;
-            reserve(char_size);
-
-            if (char_size == 1)
-            {
-                ptr[len++] = (static_cast<char>(codepoint));
-            }
-            else if (char_size == 2)
-            {
-                ptr[len++] = (static_cast<char>(0xC0 | (codepoint >> 6)));
-                ptr[len++] = (static_cast<char>(0x80 | (codepoint & 0x3F)));
-            }
-            else if (char_size == 3)
-            {
-                ptr[len++] = (static_cast<char>(0xE0 | (codepoint >> 12)));
-                ptr[len++] = (static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
-                ptr[len++] = (static_cast<char>(0x80 | (codepoint & 0x3F)));
-            }
-            else
-            {
-                ptr[len++] = (static_cast<char>(0xF0 | (codepoint >> 18)));
-                ptr[len++] = (static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
-                ptr[len++] = (static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
-                ptr[len++] = (static_cast<char>(0x80 | (codepoint & 0x3F)));
-            }
+            write_codepoint(codepoint);
         }
+        ptr[len] = '\0';
+    }
+
+    void string_buffer::write_utf32_as_utf8(const char32_t* utf32, int utflength) noexcept
+    {
+        reserve(utflength); // ASCII stays one byte per code point
+        for (int i = 0; i < utflength; ++i)
+            write_codepoint(utf32[i]); // UTF-32 carries the code point already, no surrogates
         ptr[len] = '\0';
     }
 #endif // RPP_ENABLE_UNICODE

--- a/src/rpp/sprint.cpp
+++ b/src/rpp/sprint.cpp
@@ -200,11 +200,11 @@ namespace rpp
         ptr[len] = '\0';
     }
 
-    void string_buffer::write_utf32_as_utf8(const char32_t* utf32, int utflength) noexcept
+    void string_buffer::write_wide32_as_utf8(const wchar_t* wide, int widelength) noexcept
     {
-        reserve(utflength); // ASCII stays one byte per code point
-        for (int i = 0; i < utflength; ++i)
-            write_codepoint(utf32[i]); // UTF-32 carries the code point already, no surrogates
+        reserve(widelength); // ASCII stays one byte per code point
+        for (int i = 0; i < widelength; ++i)
+            write_codepoint(static_cast<char32_t>(wide[i])); // UTF-32 needs no surrogate pair
         ptr[len] = '\0';
     }
 #endif // RPP_ENABLE_UNICODE

--- a/src/rpp/sprint.cpp
+++ b/src/rpp/sprint.cpp
@@ -200,6 +200,7 @@ namespace rpp
         ptr[len] = '\0';
     }
 
+#if RPP_WCHAR_IS_UTF32
     void string_buffer::write_wide32_as_utf8(const wchar_t* wide, int widelength) noexcept
     {
         reserve(widelength); // ASCII stays one byte per code point
@@ -207,6 +208,7 @@ namespace rpp
             write_codepoint(static_cast<char32_t>(wide[i])); // UTF-32 needs no surrogate pair
         ptr[len] = '\0';
     }
+#endif // RPP_WCHAR_IS_UTF32
 #endif // RPP_ENABLE_UNICODE
 
     static const char HEX[16]   = { '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f' };

--- a/src/rpp/sprint.h
+++ b/src/rpp/sprint.h
@@ -143,11 +143,12 @@ namespace rpp
 #if RPP_ENABLE_UNICODE
         // input as UTF-16 string, converted directly to UTF-8
         void write_utf16_as_utf8(const char16_t* utf16, int utflength) noexcept;
-        /// @brief Appends wide text where a wchar_t holds UTF-32, which is every
-        ///        platform except Windows. It takes wchar_t, because reading a wchar_t
-        ///        through a char32_t pointer breaks strict aliasing.
-        void write_wide32_as_utf8(const wchar_t* wide, int widelength) noexcept;
     private:
+    #if RPP_WCHAR_IS_UTF32
+        /// @brief Appends wide text where a wchar_t holds UTF-32. It takes wchar_t, because
+        ///        reading a wchar_t through a char32_t pointer breaks strict aliasing.
+        void write_wide32_as_utf8(const wchar_t* wide, int widelength) noexcept;
+    #endif
         /// @brief Appends one code point as 1 to 4 UTF-8 bytes. It writes no terminator,
         ///        so only a caller that terminates the buffer afterwards may use it.
         void write_codepoint(char32_t codepoint) noexcept;
@@ -160,12 +161,16 @@ namespace rpp
     #endif
         // support Wide Strings by converting them to UTF-8. Windows holds UTF-16 in a
         // wchar_t and every other platform holds UTF-32, so the decoder must match the size.
+        // A wrong macro picks the wrong decoder and corrupts the text, so prove it here.
+        static_assert(RPP_WCHAR_IS_UTF32 == (sizeof(wchar_t) == 4),
+                      "RPP_WCHAR_IS_UTF32 does not match wchar_t on this compiler");
         FINLINE void write_wide_as_utf8(const wchar_t* wide, int widelength) noexcept
         {
-            if constexpr (sizeof(wchar_t) == 2)
-                write_utf16_as_utf8(reinterpret_cast<const char16_t*>(wide), widelength);
-            else
-                write_wide32_as_utf8(wide, widelength);
+        #if RPP_WCHAR_IS_UTF32
+            write_wide32_as_utf8(wide, widelength);
+        #else
+            write_utf16_as_utf8(reinterpret_cast<const char16_t*>(wide), widelength);
+        #endif
         }
         FINLINE void write(const std::wstring& value) noexcept { write_wide_as_utf8(value.data(), static_cast<int>(value.size())); }
         FINLINE void write(std::wstring_view value)   noexcept { write_wide_as_utf8(value.data(), static_cast<int>(value.size())); }

--- a/src/rpp/sprint.h
+++ b/src/rpp/sprint.h
@@ -143,10 +143,15 @@ namespace rpp
 #if RPP_ENABLE_UNICODE
         // input as UTF-16 string, converted directly to UTF-8
         void write_utf16_as_utf8(const char16_t* utf16, int utflength) noexcept;
-        /// @brief Appends UTF-32, which is what a wchar_t holds outside Windows
-        void write_utf32_as_utf8(const char32_t* utf32, int utflength) noexcept;
-        /// @brief Appends one code point as 1 to 4 UTF-8 bytes
+        /// @brief Appends wide text where a wchar_t holds UTF-32, which is every
+        ///        platform except Windows. It takes wchar_t, because reading a wchar_t
+        ///        through a char32_t pointer breaks strict aliasing.
+        void write_wide32_as_utf8(const wchar_t* wide, int widelength) noexcept;
+    private:
+        /// @brief Appends one code point as 1 to 4 UTF-8 bytes. It writes no terminator,
+        ///        so only a caller that terminates the buffer afterwards may use it.
         void write_codepoint(char32_t codepoint) noexcept;
+    public:
 
     // Qt support for QString and QStringView with automatic fast conversion to UTF-8
     #if RPP_HAS_QT
@@ -160,7 +165,7 @@ namespace rpp
             if constexpr (sizeof(wchar_t) == 2)
                 write_utf16_as_utf8(reinterpret_cast<const char16_t*>(wide), widelength);
             else
-                write_utf32_as_utf8(reinterpret_cast<const char32_t*>(wide), widelength);
+                write_wide32_as_utf8(wide, widelength);
         }
         FINLINE void write(const std::wstring& value) noexcept { write_wide_as_utf8(value.data(), static_cast<int>(value.size())); }
         FINLINE void write(std::wstring_view value)   noexcept { write_wide_as_utf8(value.data(), static_cast<int>(value.size())); }

--- a/src/rpp/sprint.h
+++ b/src/rpp/sprint.h
@@ -143,16 +143,28 @@ namespace rpp
 #if RPP_ENABLE_UNICODE
         // input as UTF-16 string, converted directly to UTF-8
         void write_utf16_as_utf8(const char16_t* utf16, int utflength) noexcept;
+        /// @brief Appends UTF-32, which is what a wchar_t holds outside Windows
+        void write_utf32_as_utf8(const char32_t* utf32, int utflength) noexcept;
+        /// @brief Appends one code point as 1 to 4 UTF-8 bytes
+        void write_codepoint(char32_t codepoint) noexcept;
 
     // Qt support for QString and QStringView with automatic fast conversion to UTF-8
     #if RPP_HAS_QT
         FINLINE void write(const QString& str)     noexcept { write_utf16_as_utf8(reinterpret_cast<const char16_t*>(str.constData()), str.length()); }
         FINLINE void write(const QStringView& str) noexcept { write_utf16_as_utf8(reinterpret_cast<const char16_t*>(str.data()), str.length()); }
     #endif
-        // support Wide Strings by converting them to UTF-8
-        FINLINE void write(const std::wstring& value) noexcept { write_utf16_as_utf8(reinterpret_cast<const char16_t*>(value.data()), static_cast<int>(value.size())); }
-        FINLINE void write(std::wstring_view value)   noexcept { write_utf16_as_utf8(reinterpret_cast<const char16_t*>(value.data()), static_cast<int>(value.size())); }
-        FINLINE void write(const wchar_t* value)      noexcept { write_utf16_as_utf8(reinterpret_cast<const char16_t*>(value), utf16len(value)); }
+        // support Wide Strings by converting them to UTF-8. Windows holds UTF-16 in a
+        // wchar_t and every other platform holds UTF-32, so the decoder must match the size.
+        FINLINE void write_wide_as_utf8(const wchar_t* wide, int widelength) noexcept
+        {
+            if constexpr (sizeof(wchar_t) == 2)
+                write_utf16_as_utf8(reinterpret_cast<const char16_t*>(wide), widelength);
+            else
+                write_utf32_as_utf8(reinterpret_cast<const char32_t*>(wide), widelength);
+        }
+        FINLINE void write(const std::wstring& value) noexcept { write_wide_as_utf8(value.data(), static_cast<int>(value.size())); }
+        FINLINE void write(std::wstring_view value)   noexcept { write_wide_as_utf8(value.data(), static_cast<int>(value.size())); }
+        FINLINE void write(const wchar_t* value)      noexcept { write_wide_as_utf8(value, utf16len(value)); }
         // support UTF16 strings directly
         FINLINE void write(const ustring& value)  noexcept { write_utf16_as_utf8(value.data(), static_cast<int>(value.size())); }
         FINLINE void write(ustrview value)        noexcept { write_utf16_as_utf8(value.data(), static_cast<int>(value.size())); }

--- a/src/rpp/sprint.h
+++ b/src/rpp/sprint.h
@@ -145,12 +145,10 @@ namespace rpp
         void write_utf16_as_utf8(const char16_t* utf16, int utflength) noexcept;
     private:
     #if RPP_WCHAR_IS_UTF32
-        /// @brief Appends wide text where a wchar_t holds UTF-32. It takes wchar_t, because
-        ///        reading a wchar_t through a char32_t pointer breaks strict aliasing.
+        /// @brief Appends UTF-32 wide text. Takes wchar_t, because a char32_t* would alias it.
         void write_wide32_as_utf8(const wchar_t* wide, int widelength) noexcept;
     #endif
-        /// @brief Appends one code point as 1 to 4 UTF-8 bytes. It writes no terminator,
-        ///        so only a caller that terminates the buffer afterwards may use it.
+        /// @brief Appends one code point as 1 to 4 UTF-8 bytes. The caller writes the terminator.
         void write_codepoint(char32_t codepoint) noexcept;
     public:
 
@@ -159,8 +157,7 @@ namespace rpp
         FINLINE void write(const QString& str)     noexcept { write_utf16_as_utf8(reinterpret_cast<const char16_t*>(str.constData()), str.length()); }
         FINLINE void write(const QStringView& str) noexcept { write_utf16_as_utf8(reinterpret_cast<const char16_t*>(str.data()), str.length()); }
     #endif
-        // support Wide Strings by converting them to UTF-8. Windows holds UTF-16 in a
-        // wchar_t and every other platform holds UTF-32, so the decoder must match the size.
+        // support Wide Strings by converting them to UTF-8
         FINLINE void write_wide_as_utf8(const wchar_t* wide, int widelength) noexcept
         {
         #if RPP_WCHAR_IS_UTF32

--- a/src/rpp/sprint.h
+++ b/src/rpp/sprint.h
@@ -161,9 +161,6 @@ namespace rpp
     #endif
         // support Wide Strings by converting them to UTF-8. Windows holds UTF-16 in a
         // wchar_t and every other platform holds UTF-32, so the decoder must match the size.
-        // A wrong macro picks the wrong decoder and corrupts the text, so prove it here.
-        static_assert(RPP_WCHAR_IS_UTF32 == (sizeof(wchar_t) == 4),
-                      "RPP_WCHAR_IS_UTF32 does not match wchar_t on this compiler");
         FINLINE void write_wide_as_utf8(const wchar_t* wide, int widelength) noexcept
         {
         #if RPP_WCHAR_IS_UTF32

--- a/src/rpp/tests.cpp
+++ b/src/rpp/tests.cpp
@@ -749,6 +749,16 @@ namespace rpp
                 consolef(Red, "%s::%s FAILED %s\n", name.str, test.name.str, get_time_str(test.elapsed_time));
         }
 
+        // A detached pool task outlives the case that started it, and it destroys its promise
+        // whenever it finishes. TSAN reports that free against whatever the next case does with
+        // the same address. Wait here, so no case inherits the work of the one before it.
+        rpp::thread_pool& pool = rpp::thread_pool::global();
+        rpp::Timer drain;
+        while (pool.active_tasks() > 0 && drain.elapsed_millis() < 1000.0)
+            rpp::sleep_ms(1);
+        if (int leaked = pool.active_tasks(); leaked > 0)
+            consolef(Yellow, "%s::%s left %d pool task(s) running\n", name.str, test.name.str, leaked);
+
         return test.success;
     }
 

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -784,15 +784,14 @@ TestImpl(test_event_loop)
 
         AssertGreater(loop->background_tasks(), 0);
 
-        // let it finish, then spin until the awaiter has posted the resume event.
-        // A bare sleep_ms(N) would be a race: the bg thread must finish its work,
-        // call fetch_sub, and call post_resume before we sample the counters.
+        // post_resume_from_suspension() posts the resume BEFORE it drops the counter,
+        // so a pending completion alone does not prove the counter reached 0 yet
         bg_may_finish.store(true);
-        while (loop->pending_completions() == 0)
+        rpp::Timer drain;
+        while ((loop->pending_completions() == 0 || loop->background_tasks() != 0)
+               && drain.elapsed_ms() < 1000.0)
             rpp::sleep_ms(1);
 
-        // the background task finished: the resume event should be pending
-        // and background_tasks should drop back to 0
         AssertThat(loop->background_tasks(), 0);
         AssertGreater(loop->pending_completions(), 0);
 

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -29,6 +29,8 @@ TestImpl(test_event_loop)
 #if RPP_HAS_COROUTINES
 
     rpp::AtomicTimeSource clock;
+    // a loop can hold a raw pointer to this pool, so the pool must outlive the loop
+    std::unique_ptr<rpp::thread_pool> custom_pool;
     std::unique_ptr<rpp::event_loop> loop;
     const uint64 main_tid = rpp::get_thread_id();
 
@@ -46,7 +48,8 @@ TestImpl(test_event_loop)
     }
     TestCaseCleanup()
     {
-        loop.reset();
+        loop.reset();        // the loop may point at custom_pool, so it goes first
+        custom_pool.reset(); // and only then may the pool and its mutex die
     }
 
     void assert_on_main_thread(RPP_SOURCE_LOC) { AssertThatLoc(loc, rpp::get_thread_id(), main_tid); }
@@ -737,8 +740,10 @@ TestImpl(test_event_loop)
     // ─── Constructor with explicit thread pool ──────────────────
     TestCaseCoro(custom_thread_pool)
     {
-        rpp::thread_pool pool;
-        loop = std::make_unique<rpp::event_loop>(0, &pool);
+        // a local pool would die when this case returns, and TestCaseCleanup destroys the
+        // loop after that, so a worker could touch the destroyed pool mutex
+        custom_pool = std::make_unique<rpp::thread_pool>();
+        loop = std::make_unique<rpp::event_loop>(0, custom_pool.get());
 
         std::atomic<bool> bg_ran_on_custom_pool{false};
         int result = co_await loop->run_async([&]() -> int {

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -1284,11 +1284,13 @@ TestImpl(test_event_loop)
     // without a blocking get() — the continuation resumes on this thread, so we pump.
     TestCase(run_until_ready_pumps_future_on_owner_thread)
     {
-        rpp::cfuture<int> fut = [&]() -> rpp::cfuture<int>
+        // the closure must outlive the coroutine, which reads its captures after the suspend
+        auto coro = [&]() -> rpp::cfuture<int>
         {
             int v = co_await loop->run_async([] { rpp::sleep_ms(5); return 7; });
             co_return v * 6;
-        }();
+        };
+        rpp::cfuture<int> fut = coro();
         int result = loop->run_until_ready(fut);
         AssertThat(result, 42);
     }
@@ -1296,11 +1298,13 @@ TestImpl(test_event_loop)
     // pump_until_ready returns false on timeout instead of blocking on get().
     TestCase(pump_until_ready_times_out_without_blocking)
     {
-        rpp::cfuture<int> fut = [&]() -> rpp::cfuture<int>
+        // the closure must outlive the coroutine, which reads its captures after the suspend
+        auto coro = [&]() -> rpp::cfuture<int>
         {
             co_await loop->run_async([] { rpp::sleep_ms(200); return 1; });
             co_return 1;
-        }();
+        };
+        rpp::cfuture<int> fut = coro();
         rpp::Timer wall;
         bool ready = loop->pump_until_ready(fut, rpp::millis(20));
         double pump_ms = wall.elapsed_ms();

--- a/tests/test_semaphore.cpp
+++ b/tests/test_semaphore.cpp
@@ -112,6 +112,17 @@ TestImpl(test_semaphore)
         }
     }
 
+    /// @brief Waits until the worker counts every notify it was sent.
+    /// The worker counts one notify per loop, and each loop sleeps first. Stopping it the
+    /// moment the last notify goes out drops whatever it has not drained yet. The bound
+    /// makes a stuck worker fail the assert instead of hanging the suite.
+    static void drain_notifies(const std::atomic_int& counted, int expected) noexcept
+    {
+        rpp::Timer drain;
+        while (counted < expected && drain.elapsed_millis() < 2000.0)
+            rpp::sleep_ms(1);
+    }
+
     TestCase(can_notify_worker_thread)
     {
         rpp::semaphore sem;
@@ -137,12 +148,7 @@ TestImpl(test_semaphore)
             rpp::sleep_ms(2);
         }
 
-        // The worker counts one notify per loop, and each loop sleeps first. Stopping it
-        // the moment the last notify goes out drops whatever it has not drained yet.
-        rpp::Timer drain;
-        while (num_notified < num_notifies_sent && drain.elapsed_millis() < 2000.0)
-            rpp::sleep_ms(1);
-
+        drain_notifies(num_notified, num_notifies_sent);
         working = false;
         sem.notify(); // notify finished
         worker.join();
@@ -176,7 +182,7 @@ TestImpl(test_semaphore)
             spin_sleep_for_us(100);
         }
 
-        spin_sleep_for_us(5000);
+        drain_notifies(num_notified, num_notifies_sent);
         working = false;
         sem.notify(); // notify finished
         worker.join();

--- a/tests/test_semaphore.cpp
+++ b/tests/test_semaphore.cpp
@@ -112,10 +112,7 @@ TestImpl(test_semaphore)
         }
     }
 
-    /// @brief Waits until the worker counts every notify it was sent.
-    /// The worker counts one notify per loop, and each loop sleeps first. Stopping it the
-    /// moment the last notify goes out drops whatever it has not drained yet. The bound
-    /// makes a stuck worker fail the assert instead of hanging the suite.
+    /// @brief Waits for the worker to count every notify, so stopping it drops none.
     static void drain_notifies(const std::atomic_int& counted, int expected) noexcept
     {
         rpp::Timer drain;

--- a/tests/test_sprint.cpp
+++ b/tests/test_sprint.cpp
@@ -253,6 +253,28 @@ TestImpl(test_sprint)
         sb.clear();
     }
 
+    // Windows holds UTF-16 in a wchar_t and every other platform holds UTF-32. Reading
+    // UTF-32 as UTF-16 truncated "hello world" to "h" and still reported a length of 11.
+    TestCase(string_buffer_write_wide_string)
+    {
+        string_buffer sb;
+        sb.write(L"hello world");
+        AssertThat(sb.view(), "hello world");
+        sb.clear();
+
+        sb.write(std::wstring{L"abcdef"});
+        AssertThat(sb.view(), "abcdef");
+        sb.clear();
+
+        sb.write(std::wstring_view{L"äöü"}); // 2 UTF-8 bytes per code point
+        AssertThat(sb.view(), u8"äöü");
+        AssertThat(sb.size(), 6);
+        sb.clear();
+
+        sb.write(L""); // an empty wide string appends nothing
+        AssertThat(sb.size(), 0);
+    }
+
     TestCase(string_buffer_shift_op)
     {
         string_buffer sb;

--- a/tests/test_sprint.cpp
+++ b/tests/test_sprint.cpp
@@ -266,8 +266,10 @@ TestImpl(test_sprint)
         AssertThat(sb.view(), "abcdef");
         sb.clear();
 
-        sb.write(std::wstring_view{L"äöü"}); // 2 UTF-8 bytes per code point
-        AssertThat(sb.view(), u8"äöü");
+        // \u escapes, not literal text: this file carries no BOM, so MSVC would read a
+        // non-ASCII byte as the system codepage
+        sb.write(std::wstring_view{L"\u00e4\u00f6\u00fc"}); // ae oe ue, 2 UTF-8 bytes each
+        AssertThat(sb.view(), u8"\u00e4\u00f6\u00fc");
         AssertThat(sb.size(), 6);
         sb.clear();
 

--- a/tests/test_sprint.cpp
+++ b/tests/test_sprint.cpp
@@ -261,6 +261,9 @@ TestImpl(test_sprint)
     // UTF-32 as UTF-16 truncated "hello world" to "h" and still reported a length of 11.
     TestCase(string_buffer_write_wide_string)
     {
+        // a wrong macro selects the wrong decoder, which is the corruption this case pins
+        AssertThat(RPP_WCHAR_IS_UTF32 == 1, sizeof(wchar_t) == 4);
+
         string_buffer sb;
         sb.write(L"hello world");
         AssertThat(sb.view(), "hello world");

--- a/tests/test_sprint.cpp
+++ b/tests/test_sprint.cpp
@@ -1,3 +1,6 @@
+﻿#if _MSC_VER
+#pragma execution_character_set("utf-8")
+#endif
 #include <rpp/sprint.h>
 #include <rpp/file_io.h>
 #include <map>
@@ -266,10 +269,8 @@ TestImpl(test_sprint)
         AssertThat(sb.view(), "abcdef");
         sb.clear();
 
-        // \u escapes, not literal text: this file carries no BOM, so MSVC would read a
-        // non-ASCII byte as the system codepage
-        sb.write(std::wstring_view{L"\u00e4\u00f6\u00fc"}); // ae oe ue, 2 UTF-8 bytes each
-        AssertThat(sb.view(), u8"\u00e4\u00f6\u00fc");
+        sb.write(std::wstring_view{L"äöü"}); // 2 UTF-8 bytes per code point
+        AssertThat(sb.view(), u8"äöü");
         AssertThat(sb.size(), 6);
         sb.clear();
 

--- a/tests/test_sprint.cpp
+++ b/tests/test_sprint.cpp
@@ -256,6 +256,7 @@ TestImpl(test_sprint)
         sb.clear();
     }
 
+#if RPP_ENABLE_UNICODE // config.h turns this off for macOS, MIPS, Yocto and Raspi
     // Windows holds UTF-16 in a wchar_t and every other platform holds UTF-32. Reading
     // UTF-32 as UTF-16 truncated "hello world" to "h" and still reported a length of 11.
     TestCase(string_buffer_write_wide_string)
@@ -277,6 +278,7 @@ TestImpl(test_sprint)
         sb.write(L""); // an empty wide string appends nothing
         AssertThat(sb.size(), 0);
     }
+#endif // RPP_ENABLE_UNICODE
 
     TestCase(string_buffer_shift_op)
     {


### PR DESCRIPTION
Ten fixes. The first is the one the branch is named for. The rest came out of CI and the reviews while this PR was open.

## 1. string_buffer wrote one character for a whole wide string

Measured on Linux before the fix:

```
write(L"hello world")    -> 'h'   (size() reported 11)
write(wstring "abcdef")  -> 'a'   (size() reported 6)
```

Three overloads reinterpreted their data as UTF-16, but only Windows holds UTF-16 in a
`wchar_t`. Linux, macOS and Android hold UTF-32, so the decoder read the low half of each
code point and stopped at the first embedded zero. Both the text and the length were
wrong, and nothing reported an error.

`write_wide_as_utf8()` now picks the decoder from `RPP_WCHAR_IS_UTF32`. The UTF-8 encoder
moved out of `write_utf16_as_utf8()` into `write_codepoint()`, so the UTF-32 path reuses
it instead of carrying a second copy.

Verified on both widths, because MSVC is not available in the dev container:

| Build | `wchar_t` | Decoder result |
|---|---|---|
| native Linux | 32 bit | `"hello world"` at 11 bytes, `"äöü"` at 6 |
| `-fshort-wchar` | 16 bit, as Windows | `"hello world"` at 11 bytes, `"äöü"` at 6 |

**What `-fshort-wchar` does not prove.** It changes the compiler, not libc. `wcslen` keeps
its 4-byte ABI, so under that flag `wcslen(L"hello world")` returns 7 and the length path
through `utf16len()` reads garbage. The table above therefore covers the decoder with an
explicit length, and nothing more. MSVC ships a matching 2-byte `wcslen`, so this is a
limit of the Linux proxy rather than a defect. Only the Windows CI job covers that path.

## 2. A detached pool task freed its promise after its test had ended

Two TSAN reports from CI, both the same shape: `operator delete` from `~promise()` on a
pool worker, against the main thread in `pthread_cond_wait`. The thread-creation stack
named an **earlier** test every time — a task from `test_close_sync.cpp:29` freeing during
`test_concurrent_queue`, and one from `test_future.cpp:103` freeing during a later
`test_future` case.

`async_task`, `cfuture::then()` and the semaphore `co_await` all post through
`parallel_task_detached`. The task owns the promise and nothing joins it, so it frees the
promise long after `.get()` released the waiter, and the allocator hands that address to
the next case.

`run_test_func` now waits for `thread_pool::global().active_tasks()` to reach 0 after every
case, bounded at one second, and warns when a case leaves work running. That covers all 31
suites. Verified the signal is live: `active_tasks()` reads 1 while a detached task sleeps,
and the drain returns the moment it hits 0. No measurable cost — the suite runs 6.28s
against 6.14s before.

This is `BUGS.md` B9, which stays open: the library ordering is unchanged, so a consumer
that detaches a task still owns the same lifetime problem.

## 3. The event_loop test outlived the pool it pointed at

`test_event_loop::custom_thread_pool` built a **local** `rpp::thread_pool` and handed the
loop a raw pointer to it. The case returns, the local pool dies, and only then does
`TestCaseCleanup()` destroy the loop. Android caught it:
`FORTIFY: pthread_mutex_trylock called on a destroyed mutex`, then `SIGABRT` on
`rpp_task_13`, during the following case. It reads as a flake because it needs the worker
to still be running, but it is a use-after-free.

The pool is a fixture member now, and cleanup destroys the loop first. Recorded as B10,
including the part that outlives this test: `event_loop` takes a raw `thread_pool*` and
documents no lifetime rule.

## 4 and 5. From the Codex review

- `write_codepoint()` advances `len` and writes no terminator, so a public caller could
  leave the buffer without one. It is private now, rather than paying a terminator store
  per code point.
- The wide path reached the UTF-32 encoder through a `reinterpret_cast` of `wchar_t`
  storage. Equal size does not make that access type-safe. `write_wide32_as_utf8()` takes
  `wchar_t` and casts each value instead.

## 6. The new test needed a Unicode guard

`config.h` sets `RPP_ENABLE_UNICODE 0` for macOS, MIPS, Yocto and Raspi, and all three
wide `write()` overloads live inside that guard. The test called them unguarded, so on
those platforms the call would bind to a generic fallback. Verified with
`-DRPP_ENABLE_UNICODE=0`: clean build, `test_sprint` runs 15 of 16.

## 7. write_wide32_as_utf8 is private and 32-bit only

The method decodes UTF-32, so a 16-bit `wchar_t` target has no use for it. It was public,
and on such a target it looked like a second entry point next to `write_utf16_as_utf8()`
that silently produced wrong text.

`RPP_WCHAR_IS_UTF32` in `config.h` now keeps it out of the build entirely when a `wchar_t`
holds UTF-16, and it is private besides. The preprocessor cannot evaluate `sizeof`, so the
macro reads `__SIZEOF_WCHAR_T__` and falls back to `_WIN32`. A `static_assert` beside the
macro in `config.h` fails the build if that guess ever disagrees with `sizeof(wchar_t)`,
so a new compiler gives a build error rather than silent corruption.

It sat in the class at first. Review moved it to `config.h`, which also closed a hole: in
the class it lived inside `#if RPP_ENABLE_UNICODE`, so it never compiled on macOS, MIPS,
Yocto or Raspi. `-DRPP_ENABLE_UNICODE=0 -DRPP_WCHAR_IS_UTF32=0` compiled clean before and
stops the build now.

`write_wide_as_utf8()` dispatches with `#if` instead of `if constexpr`. A discarded
`if constexpr` branch in a non-template function still needs its name to resolve, so
`if constexpr` alone breaks the build once the method disappears.

## 8. The sub-millisecond semaphore test dropped notifies

CI measured 465 notifies of 500 on gcc-14. This repeats the defect B2 already fixed at
`test_semaphore.cpp:132`, because the sibling test never got that fix. It waited a fixed
5000 us instead of waiting for the count, so a slow worker lost whatever it had not
drained. Both tests call `drain_notifies()` now. Verified over 31 runs.

## 9. count_accessors read a counter the loop had not dropped yet

`post_resume_from_suspension()` posts the resume event and then drops
`num_background_suspended`. The test waited for the posted event and sampled the counter
inside that window, so it read 1 instead of 0. It waits for both now, with a bound.
Verified over 41 runs.

The loop keeps its order. A decrement before the post would leave a window where neither
counter reports the work, and `has_pending_work()` would call the loop idle while a task
is still in flight.

## 10. The consumer job only ever proved gcc

One job built ReCpp as a dependency, pinned to gcc-14, so a consumer break on clang or
MSVC reached no job. `consumer-integration` takes a compiler now, and a second job builds
the consumer with MSVC. All three clear the modules minimum: gcc-14, clang-21, and
MSVC 19.34 with a Visual Studio generator, and each keeps the modules assertion.

The clang job passes `nocache`. mama's compiler-seed cache copies `CMakeCXXCompiler.cmake`,
which makes CMake skip `CMakeDetermineCXXCompiler.cmake` — the only place that includes
`Compiler/Clang-FindBinUtils.cmake` and so the only place that finds `clang-scan-deps`.
A seeded dependency build then reports no scan-deps and silently drops modules. The
binary was present the whole time and the cache entry was absent rather than `NOTFOUND`,
which is what proves the search never ran. Recorded as B11 and reported to mamabuild.

## Gates

TSAN 501/501 with no data race, clang-tidy 0 warnings, README line references updated,
and a clean run on an idle machine after every fix.

`BUGS.md` moves B7 and B8 to Closed, adds B10 and B11, and records under B2 that the CI
flake tail does not depend on the code: a markdown-only commit failed three jobs that
passed on the commit before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJQak2qMQ4cXHtqEcpwimN