### PR TITLE
ci: gate header self-containment, and say what a failure means

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,10 @@ jobs:
         type: boolean
         default: false
         description: "Register apt.llvm.org, for a clang release the CI image does not carry"
+      check_includes:
+        type: boolean
+        default: false
+        description: "Run the header self-containment gate. One job is enough, so it is opt-in"
     description: "Ubuntu << parameters.cc_version >> C++<< parameters.cpp_version >> build with << parameters.sanitizer >> sanitizer"
     #resource_class: large # 4 CPU-s, 8GB RAM (more needed when using NINJA)
     resource_class: medium+ # medium+: 3 CPU-s, 6GB RAM, large: 4 CPU-s, 8GB RAM
@@ -72,6 +76,16 @@ jobs:
                   sudo apt-get install -y clang-tools-$LLVM_VER
       - run: pipenv install mama
       - run: pipenv run mama install-<< parameters.cc_version >>
+      - when:
+          condition: << parameters.check_includes >>
+          steps:
+            - run:
+                name: Header self-containment gate
+                command: |
+                  # every header must compile alone, so a consumer may include any one first
+                  export CXX=$([[ $COMPILER == "gcc" ]] && echo g++ || echo clang++)
+                  export CXXSTD=c++<< parameters.cpp_version >>
+                  python3 tools/check_includes.py self-contained --check
       - run: make configure-cmake
       - run:
           name: Build << parameters.cc_version >> C++<< parameters.cpp_version >> << parameters.sanitizer >>
@@ -356,6 +370,8 @@ workflows:
           coverage: false
           no_ninja: ""
           build_with_modules: "ON"
+          # one job proves header self-containment, so it runs only here
+          check_includes: true
       # Clang 21 is not in the CI image apt sources, so this job registers apt.llvm.org
       # and adds clang-tools-21, which carries the clang-scan-deps that CMake needs.
       - ubuntu-build:

--- a/tools/check_includes.py
+++ b/tools/check_includes.py
@@ -58,6 +58,17 @@ def compile_header(header: str, include_root: str) -> tuple[bool, str]:
         return p.returncode == 0, p.stderr
 
 
+def describe_failure(header: str, err: str) -> str:
+    """One line: the header, the location the compiler stopped at, and its reason."""
+    line = next((l for l in err.splitlines() if ' error: ' in l), '')
+    if not line:
+        return f'{SRC}/{header} does not compile on its own, and the compiler printed no error'
+    where, _, why = line.partition(' error: ')
+    # the compiler prints an absolute path, which is noise next to the repo-relative header
+    where = where.strip().rstrip(':').replace(os.getcwd() + os.sep, '')
+    return f'{SRC}/{header} does not compile on its own -- {where}: {why.strip()}'
+
+
 def strip_comments(src: str) -> str:
     return re.sub(r'//[^\n]*|/\*.*?\*/', '', src, flags=re.S)
 
@@ -68,8 +79,7 @@ def check_self_contained() -> list[str]:
     with ThreadPoolExecutor(max_workers=os.cpu_count()) as ex:
         for h, (ok, err) in zip(headers(), ex.map(lambda h: compile_header(h, root), headers())):
             if not ok:
-                first = next((l for l in err.splitlines() if ' error: ' in l), err.splitlines()[0] if err else '?')
-                bad.append(f'{SRC}/{h}: {first.strip()}')
+                bad.append(describe_failure(h, err))
     return bad
 
 
@@ -171,7 +181,8 @@ def main() -> int:
         if mode == 'self-contained': found, gate = (lambda r: (r, len(r)))(check_self_contained())
         elif mode == 'missing':      found, gate = (lambda r: (r, len(r)))(check_missing())
         else:                        found, gate = check_unused(a.only)
-        print(f'== {mode}: {gate} findings that fail the gate ==')
+        noun, verb = ('finding', 'fails') if gate == 1 else ('findings', 'fail')
+        print(f'== {mode}: {gate} {noun} that {verb} the gate ==')
         for line in found: print(f'  {line}')
         gated += gate
     return 1 if (a.check and gated) else 0


### PR DESCRIPTION
Every header must compile alone, so a consumer may include any one of them first. traits.h broke that once by naming std::tuple without <tuple>. The check reports 0 today, so the gate changes no include and only stops a regression.

It runs in ubuntu-cpp20-modules-gcc14 alone, because one compiler proves the property and 15 jobs would pay 7 seconds each. The step runs before the build, so a header defect fails in seconds instead of after a full build.

The finding now names the header, the location and the compiler reason, without repeating the absolute path:
  src/rpp/traits.h does not compile on its own -- src/rpp/traits.h:23:36: no
  template named 'tuple' in namespace 'std'
When the error surfaces in another header, that header is the location, so the reader sees which one to fix.