### PR TITLE
fix: _va_comma dropped the argument list 

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -20,11 +20,16 @@ kill %1 %2
 
 
 ### B5. `update_doc_linerefs.py` matches a macro name inside another macro body
-It pointed `LogError` at `debugging.macros.h:151`, which is the `LogError` call
-inside `DbgAssert`, not the `#define LogError` at line 128. Corrected by hand.
+It pointed `LogError` at `debugging.macros.h:162`, which is the `LogError` call
+inside `DbgAssert`, not the `#define LogError` at line 139. Corrected by hand.
 The script's own docstring already warns that it has mistakes.
 
 ## Closed
+
+### C24. `_va_comma` dropped the argument list when the first argument started with `(`
+The one-probe fallback let `_spaces_on_empty_token` consume that leading paren, so the
+list read as empty and printf then read an unwritten stack slot. The 4-probe emptiness
+test replaces it, and `test_debugging` pins the fallback on every compiler.
 
 ### C23. `udp_poll_multi_stress_test` never sized its receive queue (CI flake)
 The default 208 KB queue holds only 270 of the 500 datagrams, so a pre-empted CI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,12 @@ if (BUILD_TESTS)
         ${TRACE_LIBRARY}
         Threads::Threads
     )
+    if (MSVC AND NOT CLANG) # clang-cl keeps MSVC true and drops the flag unused
+        # this TU is the only gate on the _va_comma fallback a consumer without /Zc:preprocessor compiles
+        # the D9025 override warning is expected, never delete this block to silence it
+        set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/tests/test_debugging.cpp
+                                    PROPERTIES COMPILE_OPTIONS "/Zc:preprocessor-")
+    endif()
     install(TARGETS RppTests DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/bin)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -3778,10 +3778,10 @@ Cross-platform logging with severity filtering, log handlers, timestamps, and as
 
 | Macro | Description |
 |-------|-------------|
-| [`LogInfo(format, ...)`](src/rpp/debugging.macros.h#L116) | Log informational message |
-| [`LogWarning(format, ...)`](src/rpp/debugging.macros.h#L122) | Log warning |
-| [`LogError(format, ...)`](src/rpp/debugging.macros.h#L128) | Log error (debug assert) |
-| [`Assert(expression, format, ...)`](src/rpp/debugging.macros.h#L142) | Conditional error log |
+| [`LogInfo(format, ...)`](src/rpp/debugging.macros.h#L127) | Log informational message |
+| [`LogWarning(format, ...)`](src/rpp/debugging.macros.h#L133) | Log warning |
+| [`LogError(format, ...)`](src/rpp/debugging.macros.h#L139) | Log error (debug assert) |
+| [`Assert(expression, format, ...)`](src/rpp/debugging.macros.h#L153) | Conditional error log |
 
 ### Configuration Functions
 

--- a/src/rpp/debugging.macros.h
+++ b/src/rpp/debugging.macros.h
@@ -28,23 +28,32 @@
 #define _rpp_get_nth_wrap_arg(zero, _12,_11,_10,_9,  _8,_7,_6,_5,  _4,_3,_2,_1,  N_0, ...) N_0
 #define _rpp_wrap(x) x
 
-// _va_comma(__VA_ARGS__): expands to `,` if __VA_ARGS__ is non-empty, nothing if empty.
-// C++20 __VA_OPT__ is preferred because the fallback (_spaces_on_empty_token trick)
-// breaks when __VA_ARGS__ starts with a C-style cast like (long long)(expr) --
-// the function-like _spaces_on_empty_token macro greedily consumes (long long) as its argument.
-// MSVC requires /Zc:preprocessor for __VA_OPT__; _MSVC_TRADITIONAL==0 confirms it is active.
-// Library consumers without /Zc:preprocessor will use the fallback automatically.
+// _rpp_is_empty(__VA_ARGS__) gives 1 for an empty list and 0 otherwise, from 4 probes.
+// Probe 2 keeps a leading `(` out of the empty case, see BUGS.md C24.
+#define _rpp_arg16(_0,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15,...) _15
+#define _rpp_has_comma(...) _rpp_wrap(_rpp_arg16(__VA_ARGS__, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,0))
+#define _rpp_trigger_paren(...) ,
+#define _rpp_paste5(_0,_1,_2,_3,_4) _0##_1##_2##_3##_4
+#define _rpp_is_empty_case_0001 ,
+#define _rpp_is_empty_impl(_0,_1,_2,_3) _rpp_has_comma(_rpp_paste5(_rpp_is_empty_case_,_0,_1,_2,_3))
+#define _rpp_is_empty(...) _rpp_wrap(_rpp_is_empty_impl(_rpp_has_comma(__VA_ARGS__), \
+    _rpp_has_comma(_rpp_trigger_paren __VA_ARGS__), _rpp_has_comma(__VA_ARGS__ (/*empty*/)), \
+    _rpp_has_comma(_rpp_trigger_paren __VA_ARGS__ (/*empty*/))))
+#define _rpp_comma_if_0 ,
+#define _rpp_comma_if_1
+#define _rpp_cat2(a,b) a##b
+#define _rpp_cat(a,b) _rpp_cat2(a,b)
+
+// _va_comma(__VA_ARGS__) and its fallback give `,` for a non-empty list, nothing for an empty one.
+// The fallback expands the list first, so an argument which expands to nothing also reads as empty.
+#define _rpp_va_comma_fallback(...) _rpp_wrap(_rpp_cat(_rpp_comma_if_, _rpp_is_empty(__VA_ARGS__)))
+
+// MSVC needs /Zc:preprocessor for __VA_OPT__, and _MSVC_TRADITIONAL==0 confirms it is active.
 #if (!defined(_MSC_VER) && __cplusplus >= 202002L) \
  || (defined(_MSVC_TRADITIONAL) && _MSVC_TRADITIONAL == 0)
 #define _va_comma(...) __VA_OPT__(,)
 #else
-#define _rpp_z
-#define _rpp_c ,
-#define _spaces_on_empty_token(...) ,,,, ,,,, ,,,,
-#define _get_nth_comma(_12,_11,_10,_9,  _8,_7,_6,_5,  _4,_3,_2,_1,  N_0, ...) N_0
-#define _va_comma2(...) _rpp_wrap(_get_nth_comma(__VA_ARGS__,  _rpp_c,_rpp_c,_rpp_c,_rpp_c, \
-                                  _rpp_c,_rpp_c,_rpp_c,_rpp_c, _rpp_c,_rpp_c,_rpp_c,_rpp_c, _rpp_z) )
-#define _va_comma(...) _va_comma2(_spaces_on_empty_token __VA_ARGS__ (/*empty*/))
+#define _va_comma(...) _rpp_va_comma_fallback(__VA_ARGS__)
 #endif
 
 #define _wa0(...)
@@ -64,6 +73,8 @@
 #define _rpp_wrap_args_2(...) _rpp_wrap( _rpp_get_nth_wrap_arg(__VA_ARGS__,  _wa12,_wa11,_wa10,_wa9, \
                                                        _wa8,_wa7,_wa6,_wa5,  _wa4,_wa3,_wa2,_wa1,  _wa0)(__VA_ARGS__) )
 #define _rpp_wrap_args(...) _rpp_wrap( _rpp_wrap_args_2(0 _va_comma(__VA_ARGS__) __VA_ARGS__) )
+// the tests reach the fallback path through this, which __VA_OPT__ hides on a conforming preprocessor
+#define _rpp_wrap_args_fallback(...) _rpp_wrap( _rpp_wrap_args_2(0 _rpp_va_comma_fallback(__VA_ARGS__) __VA_ARGS__) )
 
 #else // C:
   #define _rpp_wrap_args(...) , ##__VA_ARGS__

--- a/tests/test_debugging.cpp
+++ b/tests/test_debugging.cpp
@@ -9,6 +9,19 @@ static std::string log_output;
 #define STRINGIZE2(x) #x
 #define LINE_STR STRINGIZE(__LINE__)
 
+// _va_comma picks __VA_OPT__ where the preprocessor has it, so this reaches the fallback everywhere
+#define LogInfoFallback(format, ...) _LogInfo("$ " format _rpp_wrap_args_fallback(__VA_ARGS__))
+
+template<class...T> static constexpr int va_count(T... args) { return sizeof...(args); }
+#define VaCount(...) va_count(0 _rpp_va_comma_fallback(__VA_ARGS__) __VA_ARGS__)
+
+static_assert(VaCount() == 1, "an empty list must not gain a comma");
+static_assert(VaCount(1) == 2, "one argument must gain a comma");
+static_assert(VaCount(1, 2) == 3, "two arguments must gain one comma");
+static_assert(VaCount((true) ? 1 : 2) == 2, "a leading ( must not read as an empty list");
+static_assert(VaCount((long long)(1)) == 2, "a C-style cast must not read as an empty list");
+static_assert(VaCount((true) ? 1 : 2, 3) == 3, "a leading ( must keep the arguments after it");
+
 TestImpl(test_debugging)
 {
     TestInit(test_debugging)
@@ -72,6 +85,48 @@ TestImpl(test_debugging)
         LogWarning("Warn(6): '%s', '%s', %d, %.1f, `%c`, '%s'", a, b, c, d, e, a); AssertThat(log_output, "test_debugging.cpp:" LINE_STR " test_debug_api $ Warn(6): 'string', 'strview', 42, 42.0, `4`, 'string'");
         LogWarning("Warn(7): '%s', '%s', %d, %.1f, `%c`, '%s', '%s'", a, b, c, d, e, a, b); AssertThat(log_output, "test_debugging.cpp:" LINE_STR " test_debug_api $ Warn(7): 'string', 'strview', 42, 42.0, `4`, 'string', 'strview'");
         LogWarning("Warn(8): '%s', '%s', %d, %.1f, `%c`, '%s', '%s', %d", a, b, c, d, e, a, b, c); AssertThat(log_output, "test_debugging.cpp:" LINE_STR " test_debug_api $ Warn(8): 'string', 'strview', 42, 42.0, `4`, 'string', 'strview', 42");
+    }
+
+    TestCase(paren_first_arg)
+    {
+        bool flyView = false;
+        long long v = 42;
+        log_output.clear();
+
+        LogInfo("flyView %s", (flyView) ? "true" : "false");
+        AssertThat(log_output, "$ flyView false");
+
+        LogInfo("cast %lld", (long long)(v));
+        AssertThat(log_output, "$ cast 42");
+
+        LogInfo("mixed %s %lld %d", (flyView) ? "true" : "false", (long long)(v), 7);
+        AssertThat(log_output, "$ mixed false 42 7");
+
+        LogWarning("warn %s", (flyView) ? "t" : "f"); AssertThat(log_output, "test_debugging.cpp:" LINE_STR " test_paren_first_arg $ warn f");
+
+        std::string thrown;
+        try { ThrowErr("throw %s", (flyView) ? "t" : "f"); } catch (const std::runtime_error& e) { thrown = e.what(); }
+        AssertThat(thrown, "throw f");
+    }
+
+    TestCase(paren_first_arg_va_comma_fallback)
+    {
+        log_output.clear();
+
+        LogInfoFallback("no args");
+        AssertThat(log_output, "$ no args");
+
+        LogInfoFallback("flyView %s", (false) ? "true" : "false");
+        AssertThat(log_output, "$ flyView false");
+
+        LogInfoFallback("cast %lld", (long long)(42));
+        AssertThat(log_output, "$ cast 42");
+
+        LogInfoFallback("mixed %s %lld %d", (false) ? "true" : "false", (long long)(42), 7);
+        AssertThat(log_output, "$ mixed false 42 7");
+
+        LogInfoFallback("plain %s %lld", "str", 42LL);
+        AssertThat(log_output, "$ plain str 42");
     }
 
     //TestCase(log_except)


### PR DESCRIPTION
…when the first argument star…ted with (

The single _spaces_on_empty_token probe fires as soon as the argument list starts with a parenthesis. A parenthesized ternary and a C-style cast then read as empty. Every LogInfo, LogWarning and ThrowErr in that shape passed a format string with no argument, and printf read an unwritten stack slot.

The 4-probe emptiness test replaces the single probe. Probe 2 separates a leading parenthesis from an empty list, so only the pattern 0,0,0,1 reads as empty.

_rpp_va_comma_fallback and _rpp_wrap_args_fallback stay reachable when __VA_OPT__ is selected, so test_debugging pins the fallback on every compiler. CMake compiles that one file with /Zc:preprocessor- under MSVC, which is the only gate on the traditional preprocessor a consumer without the flag uses.

Reported in https://github.com/RedFox20/ReCpp/issues/67

#67 