### PR TITLE
modules: add the L1 layer and six of L2, taking the count from 6 to 24

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -59,9 +59,20 @@ Neither module ships until a toolchain reads them back.
 Each one fails alone, so no pair of modules causes it. A consumer that includes
 `<mutex>` before the import fails the same way. The other eighteen modules import.
 
-Reproduce it. Add `src/rpp/rpp-sprint.cppm` back to `RPP_MODULES_SRC`, then:
+Reproduce it. No `rpp-sprint.cppm` ever landed, so write the skeleton first. The generator
+fills the block, and it refuses a file which carries no markers.
 ```bash
-cd tests/module_consumer   # add `import rpp.sprint;` to masked_module_only.cpp first
+cat > src/rpp/rpp-sprint.cppm <<'EOF'
+module;
+#include "sprint.h"
+export module rpp.sprint;
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+// GENERATED EXPORTS END
+EOF
+python3 tools/gen_module_exports.py sprint.h
+# add src/rpp/rpp-sprint.cppm to RPP_MODULES_SRC in CMakeLists.txt
+# add `import rpp.sprint;` to tests/module_consumer/masked_module_only.cpp
+cd tests/module_consumer
 CXX20=1 python3 run_test.py --compiler gcc --expect modules --jobs 4
 ```
 Retry it on clang-21 and on a gcc newer than 14.2. Only gcc 14.2 ran this check.

--- a/BUGS.md
+++ b/BUGS.md
@@ -49,6 +49,23 @@ inside an uninstrumented `libstdc++.so`.
 Read C15 first. A fix adds the gcc branch and a libstdc++ pattern, and it needs a run
 which proves the suppression hides this race and hides no other.
 
+### B8. gcc-14 writes a module for sprint.h and task.h that no importer can read
+Both `.cppm` files compile, and the `.gcm` lands. An importer then stops with
+`failed to read compiled module cluster N: Bad file data`, followed by
+`fatal error: failed to load pendings for 'std::_Mutex_base'`. The message names a
+libstdc++ internal, so this is a compiler defect and not an export list mistake.
+Neither module ships until a toolchain reads them back.
+
+Each one fails alone, so no pair of modules causes it. A consumer that includes
+`<mutex>` before the import fails the same way. The other eighteen modules import.
+
+Reproduce it. Add `src/rpp/rpp-sprint.cppm` back to `RPP_MODULES_SRC`, then:
+```bash
+cd tests/module_consumer   # add `import rpp.sprint;` to masked_module_only.cpp first
+CXX20=1 python3 run_test.py --compiler gcc --expect modules --jobs 4
+```
+Retry it on clang-21 and on a gcc newer than 14.2. Only gcc 14.2 ran this check.
+
 ### B5. `update_doc_linerefs.py` matches a macro name inside another macro body
 It pointed `LogError` at `debugging.macros.h:162`, which is the `LogError` call
 inside `DbgAssert`, not the `#define LogError` at line 139. Corrected by hand.

--- a/BUGS.md
+++ b/BUGS.md
@@ -77,6 +77,32 @@ CXX20=1 python3 run_test.py --compiler gcc --expect modules --jobs 4
 ```
 Retry it on clang-21 and on a gcc newer than 14.2. Only gcc 14.2 ran this check.
 
+### B9. `--check-undocumented` reads 29 of the 48 headers and reports the rest as clean
+`extract_public_decls` returns nothing for 19 headers, so the gate never asks whether
+README.md documents them. It reported "All public declarations are documented" while the
+`sort.h` table listed 1 of its 4 functions.
+
+```
+headers the extractor reads: 29
+headers it returns nothing for: 19
+  bitutils.h close_sync.h concurrent_queue.h condition_variable.h coroutines.h debugging.h
+  debugging.macros.h future.h jni_cpp.h log_colors.h math.h memory_pool.h obfuscated_string.h
+  predicates.h proc_utils.h semaphore.h sort.h task.h traits.h
+```
+
+Reproduce it with the loop which produced that count:
+```bash
+python3 -c "
+import importlib.util, os
+spec = importlib.util.spec_from_file_location('u','update_doc_linerefs.py')
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+for h in sorted(os.listdir('src/rpp')):
+    if h.endswith('.h') and not m.extract_public_decls(f'src/rpp/{h}'): print(h)
+"
+```
+A fix teaches the extractor the declaration shapes it misses, and it needs a count of what
+the 19 headers then owe README.md. The count decides whether the gate can stay green.
+
 ### B5. `update_doc_linerefs.py` matches a macro name inside another macro body
 It pointed `LogError` at `debugging.macros.h:162`, which is the `LogError` call
 inside `DbgAssert`, not the `#define LogError` at line 139. Corrected by hand.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,6 +367,13 @@ if(RPP_BUILD_MODULES)
         src/rpp/rpp-math.cppm
         src/rpp/rpp-timepoint.cppm
         src/rpp/rpp-delegate.cppm
+        # L2
+        src/rpp/rpp-atomic_timepoint.cppm
+        src/rpp/rpp-collections.cppm
+        src/rpp/rpp-stack_trace.cppm
+        src/rpp/rpp-threads.cppm
+        src/rpp/rpp-timer.cppm
+        src/rpp/rpp-vec.cppm
     )
 
     # Add module interface to the library target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,19 @@ if(RPP_BUILD_MODULES)
         src/rpp/rpp-scopeguard.cppm
         src/rpp/rpp-strview.cppm
         src/rpp/rpp-debugging.cppm
+        # L1
+        src/rpp/rpp-bitutils.cppm
+        src/rpp/rpp-traits.cppm
+        src/rpp/rpp-type_traits.cppm
+        src/rpp/rpp-source_loc.cppm
+        src/rpp/rpp-endian.cppm
+        src/rpp/rpp-predicates.cppm
+        src/rpp/rpp-sort.cppm
+        src/rpp/rpp-proc_utils.cppm
+        src/rpp/rpp-future_types.cppm
+        src/rpp/rpp-math.cppm
+        src/rpp/rpp-timepoint.cppm
+        src/rpp/rpp-delegate.cppm
     )
 
     # Add module interface to the library target

--- a/README.md
+++ b/README.md
@@ -4695,8 +4695,8 @@ Function type traits for extracting return types and argument types from callabl
 
 | Trait | Description |
 |-------|-------------|
-| [`function_traits<T>`](src/rpp/traits.h#L16) | Extracts `ret_type` and `arg_types` from functions, lambdas, member functions |
-| [`first_arg_type<T>`](src/rpp/traits.h#L50) | First argument type of a callable |
+| [`function_traits<T>`](src/rpp/traits.h#L14) | Extracts `ret_type` and `arg_types` from functions, lambdas, member functions |
+| [`first_arg_type<T>`](src/rpp/traits.h#L48) | First argument type of a callable |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4272,6 +4272,14 @@ Minimal insertion sort for smaller binary sizes compared to `std::sort`. The ins
 | Function | Description |
 |----------|-------------|
 | [`insertion_sort(data, count, comparison)`](src/rpp/sort.h#L59) | In-place insertion sort with comparator |
+| [`insertion_sort(container, comparison)`](src/rpp/sort.h#L82) | Sorts any contiguous container with a comparator |
+| [`sort(container)`](src/rpp/sort.h#L97) | Sorts any contiguous container in ascending order |
+| [`sort(container, comparison)`](src/rpp/sort.h#L112) | Sorts any contiguous container with a comparator |
+
+A contiguous container has `data()`, `size()` and `operator[]`, which `std::vector` and
+`rpp::element_range` both answer. `collections.h` adds two more overloads. One takes an
+explicit element type, as `rpp::sort<int>(v)`. The other takes an `element_range` by value,
+so a const range still sorts the elements it views.
 
 ### Example: Insertion Sort
 

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -1,10 +1,9 @@
 # ReCpp C++20 Modules Migration Plan
 
-Revision 6. Six modules exist: `rpp.config`, `rpp.minmax`, `rpp.obfuscated_string`,
-`rpp.scopeguard`, `rpp.strview` and `rpp.debugging`.
+Revision 7. Eighteen modules exist, which is the whole L0 and L1 layer.
 
 This document explains the pattern, records what real builds prove about it, and
-gives the phased plan for the remaining 38 headers.
+gives the phased plan for the remaining 26 headers.
 
 ## Handover state
 
@@ -13,21 +12,29 @@ gate, #65 changeset 6.
 
 | Item | State |
 |---|---|
-| the six modules | build and pass on gcc-14, and CI covers clang-21 and MSVC 14.44 |
+| the eighteen modules | build and pass on gcc-14, and CI covers clang-21 and MSVC 14.52 |
 | `debugging.macros.h` | split out, 50 preprocessed lines against 32893 |
 | `BUILD_WITH_MODULES=AUTO` | on per toolchain, GCC 14 / Clang 21 / MSVC 19.34 |
 | Include-order style rule | in AGENTS.md, and the `import-order` gate holds it |
 | `tools/check_includes.py` | 6 checks. 4 gate CI, and `missing` and `unused` stay ungated |
-| `tests/test_modules.cpp` | module consumer test, 3 cases |
+| `tests/test_modules.cpp` | module consumer test, 12 cases |
 | `tests/module_consumer/` | a real mama consumer, on gcc, clang and MSVC |
 | mama | 0.14.0 exports the `.cppm` files and strips the module objects |
-| CI | green, all 29 jobs, and no job pins a mama branch |
+| CI | green, 28 jobs on GitHub Actions, and CircleCI is gone |
 
 **Changeset state:** 1a is dropped, see section 4. 1b, 2, 3 and the mama half of
-6 landed. The generator drives all six modules. 4 is done through the generator
-`--check`. 5 is in progress, with the L0 layer complete. Section 11 lists what 7 owes.
+6 landed. The generator drives all eighteen modules. 4 is done through the generator
+`--check`. 5 is in progress, with L0 and L1 complete. Section 11 lists what 7 owes.
 
-**Next action:** changeset 5, the L1 layer. Section 9 has the layers.
+**Next action:** changeset 5, the L2 layer. Section 9 has the layers.
+
+**What L1 exposed.** Four headers declared public API the compiler could not export, and
+each one is fixed in the same change. `math.h` marked every function `static` and left its
+constants without `inline`. `traits.h` wrapped `function_traits` in an anonymous namespace,
+so every translation unit held a different type. `timepoint.h` left nine constants without
+`inline`. The generator itself mishandled two kinds of declaration. An out-of-line member
+definition reached the export list and broke the build. A blanket skip of `UNEXPOSED_DECL`
+hid every variable template. Both tools now carry a selftest case for the shape they missed.
 
 **Open questions:** `BUGS.md` B2 and B5. B2 reaches this work through CI, and the
 owner rules it test construction rather than a defect.
@@ -718,7 +725,7 @@ of `src/rpp/*.h`, so changeset 1b can move a header between layers.
 | Layer | Modules | Count |
 |---|---|---|
 | L0 | **config.types** ✓, **minmax** ✓, **obfuscated_string** ✓, **scope_guard** ✓ | 4 |
-| L1 | bitutils, **debugging** ✓, delegate, endian, future_types, math, predicates, proc_utils, sort, source_loc, **strview** ✓, timepoint, traits, type_traits | 14 |
+| L1 | **bitutils** ✓, **debugging** ✓, **delegate** ✓, **endian** ✓, **future_types** ✓, **math** ✓, **predicates** ✓, **proc_utils** ✓, **sort** ✓, **source_loc** ✓, **strview** ✓, **timepoint** ✓, **traits** ✓, **type_traits** ✓ | 14 |
 | L2 | atomic_timepoint, collections, sprint, stack_trace, task, threads, timer, vec | 8 |
 | L3 | load_balancer, memory_pool, mutex, paths, tests | 5 |
 | L4 | atomic_shared_ptr, close_sync, condition_variable, file_io, sockets | 5 |
@@ -728,7 +735,7 @@ of `src/rpp/*.h`, so changeset 1b can move a header between layers.
 | L8 | coroutines | 1 |
 | top | umbrella `rpp` | 1 |
 
-44 modules and one umbrella. The L0 layer, `rpp.strview` and `rpp.debugging` exist, so 38 remain. Excluded:
+44 modules and one umbrella. The L0 and L1 layers exist, so 26 remain. Excluded:
 `config.h` and `log_colors.h` by rule 1 of section 6.3, and `jni_cpp.h` because
 it is Android glue. `tests.h` is in, and it is the one header whose macros split
 into `tests_macros.h`.

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -1,9 +1,9 @@
 # ReCpp C++20 Modules Migration Plan
 
-Revision 7. Eighteen modules exist, which is the whole L0 and L1 layer.
+Revision 8. Twenty-four modules exist: all of L0 and L1, and six of the eight in L2.
 
 This document explains the pattern, records what real builds prove about it, and
-gives the phased plan for the remaining 26 headers.
+gives the phased plan for the remaining 20 headers.
 
 ## Handover state
 
@@ -12,21 +12,38 @@ gate, #65 changeset 6.
 
 | Item | State |
 |---|---|
-| the eighteen modules | build and pass on gcc-14, and CI covers clang-21 and MSVC 14.52 |
+| the twenty-four modules | build and pass on gcc-14, and CI covers clang-21 and MSVC 14.52 |
 | `debugging.macros.h` | split out, 50 preprocessed lines against 32893 |
 | `BUILD_WITH_MODULES=AUTO` | on per toolchain, GCC 14 / Clang 21 / MSVC 19.34 |
 | Include-order style rule | in AGENTS.md, and the `import-order` gate holds it |
 | `tools/check_includes.py` | 6 checks. 4 gate CI, and `missing` and `unused` stay ungated |
-| `tests/test_modules.cpp` | module consumer test, 12 cases |
+| `tests/test_modules.cpp` | module consumer test, 18 cases |
 | `tests/module_consumer/` | a real mama consumer, on gcc, clang and MSVC |
 | mama | 0.14.0 exports the `.cppm` files and strips the module objects |
 | CI | green, 28 jobs on GitHub Actions, and CircleCI is gone |
 
 **Changeset state:** 1a is dropped, see section 4. 1b, 2, 3 and the mama half of
-6 landed. The generator drives all eighteen modules. 4 is done through the generator
-`--check`. 5 is in progress, with L0 and L1 complete. Section 11 lists what 7 owes.
+6 landed. The generator drives all twenty-four modules. 4 is done through the generator
+`--check`. 5 is in progress, with L0, L1 and most of L2 complete. Section 11 lists what 7 owes.
 
-**Next action:** changeset 5, the L2 layer. Section 9 has the layers.
+**Next action, and it outranks the remaining layers: land `rpp.sprint`.** `sprint.h` carries
+`string_buffer`, `format` and every `to_string` overload, so more code depends on it than on
+any other L2 header. gcc-14 writes its module and no importer reads it back, which `BUGS.md`
+**B8** records with a reproducer. Answer three questions in order.
+
+1. Does clang-21 import `rpp.sprint`? CI runs that toolchain, and this machine carries
+   clang-18, which cannot build modules at all. A green clang-21 import makes B8 a gcc bug
+   and nothing more.
+2. Does a gcc newer than 14.2 import it? The failure names `std::_Mutex_base`, so a
+   libstdc++ or module-writer fix may already exist upstream.
+3. If both fail, cut the module surface until it reads back. `sprint.h` re-exports four
+   modules, which is more than any other L2 header, and a smaller export set narrows the
+   BMI that gcc cannot write.
+
+`rpp.task` fails the same way and waits behind the same three questions. It blocks less,
+because only the coroutine headers name it.
+
+**Then:** changeset 5, the L3 layer. Section 9 has the layers.
 
 **What L1 exposed.** Four headers declared public API the compiler could not export, and
 each one is fixed in the same change. `math.h` marked every function `static` and left its
@@ -36,7 +53,7 @@ so every translation unit held a different type. `timepoint.h` left nine constan
 definition reached the export list and broke the build. A blanket skip of `UNEXPOSED_DECL`
 hid every variable template. Both tools now carry a selftest case for the shape they missed.
 
-**Open questions:** `BUGS.md` B2 and B5. B2 reaches this work through CI, and the
+**Open questions:** `BUGS.md` B2, B5 and B8. B2 reaches this work through CI, and the
 owner rules it test construction rather than a defect.
 
 ---
@@ -726,7 +743,7 @@ of `src/rpp/*.h`, so changeset 1b can move a header between layers.
 |---|---|---|
 | L0 | **config.types** ✓, **minmax** ✓, **obfuscated_string** ✓, **scope_guard** ✓ | 4 |
 | L1 | **bitutils** ✓, **debugging** ✓, **delegate** ✓, **endian** ✓, **future_types** ✓, **math** ✓, **predicates** ✓, **proc_utils** ✓, **sort** ✓, **source_loc** ✓, **strview** ✓, **timepoint** ✓, **traits** ✓, **type_traits** ✓ | 14 |
-| L2 | atomic_timepoint, collections, sprint, stack_trace, task, threads, timer, vec | 8 |
+| L2 | **atomic_timepoint** ✓, **collections** ✓, sprint ⚠, **stack_trace** ✓, task ⚠, **threads** ✓, **timer** ✓, **vec** ✓ | 8 |
 | L3 | load_balancer, memory_pool, mutex, paths, tests | 5 |
 | L4 | atomic_shared_ptr, close_sync, condition_variable, file_io, sockets | 5 |
 | L5 | binary_stream, concurrent_queue, semaphore | 3 |
@@ -735,7 +752,9 @@ of `src/rpp/*.h`, so changeset 1b can move a header between layers.
 | L8 | coroutines | 1 |
 | top | umbrella `rpp` | 1 |
 
-44 modules and one umbrella. The L0 and L1 layers exist, so 26 remain. Excluded:
+A ⚠ marks a module gcc-14 writes but no importer reads, which `BUGS.md` **B8** tracks.
+
+44 modules and one umbrella. L0, L1 and six of L2 exist, so 20 remain. Excluded:
 `config.h` and `log_colors.h` by rule 1 of section 6.3, and `jni_cpp.h` because
 it is Android glue. `tests.h` is in, and it is the one header whose macros split
 into `tests_macros.h`.

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -1,6 +1,6 @@
 # ReCpp C++20 Modules Migration Plan
 
-Revision 8. Twenty-four modules exist: all of L0 and L1, and six of the eight in L2.
+Revision 9. Twenty-four modules exist: all of L0 and L1, and six of the eight in L2.
 
 This document explains the pattern, records what real builds prove about it, and
 gives the phased plan for the remaining 20 headers.
@@ -17,14 +17,15 @@ gate, #65 changeset 6.
 | `BUILD_WITH_MODULES=AUTO` | on per toolchain, GCC 14 / Clang 21 / MSVC 19.34 |
 | Include-order style rule | in AGENTS.md, and the `import-order` gate holds it |
 | `tools/check_includes.py` | 6 checks. 4 gate CI, and `missing` and `unused` stay ungated |
-| `tests/test_modules.cpp` | module consumer test, 18 cases |
-| `tests/module_consumer/` | a real mama consumer, on gcc, clang and MSVC |
+| `tests/test_modules.cpp` | module consumer test, 21 cases. It includes `tests.h` and the macro header only, so what those two mask needs a module-only target |
+| `tests/module_consumer/` | a real mama consumer, on gcc, clang and MSVC, with 4 module-only targets |
 | mama | 0.14.0 exports the `.cppm` files and strips the module objects |
-| CI | green, 28 jobs on GitHub Actions, and CircleCI is gone |
+| CI | 28 jobs on GitHub Actions, and CircleCI is gone |
+| test counts | 552/552 on the modules build, 531/531 on the header build |
 
 **Changeset state:** 1a is dropped, see section 4. 1b, 2, 3 and the mama half of
 6 landed. The generator drives all twenty-four modules. 4 is done through the generator
-`--check`. 5 is in progress, with L0, L1 and most of L2 complete. Section 11 lists what 7 owes.
+`--check`. 5 has L0 and L1 finished, and L2 ships six of eight. Section 11 lists what 7 owes.
 
 **Next action, and it outranks the remaining layers: land `rpp.sprint`.** `sprint.h` carries
 `string_buffer`, `format` and every `to_string` overload, so more code depends on it than on
@@ -45,16 +46,46 @@ because only the coroutine headers name it.
 
 **Then:** changeset 5, the L3 layer. Section 9 has the layers.
 
-**What L1 exposed.** Four headers declared public API the compiler could not export, and
-each one is fixed in the same change. `math.h` marked every function `static` and left its
+**What L1 and L2 exposed.** Six headers declared public API the compiler could not export,
+and each fix landed with the layer. `math.h` marked every function `static` and left its
 constants without `inline`. `traits.h` wrapped `function_traits` in an anonymous namespace,
 so every translation unit held a different type. `timepoint.h` left nine constants without
-`inline`. The generator itself mishandled two kinds of declaration. An out-of-line member
-definition reached the export list and broke the build. A blanket skip of `UNEXPOSED_DECL`
-hid every variable template. Both tools now carry a selftest case for the shape they missed.
+`inline`, and `stack_trace.h` marked `CALLSTACK_MAX_DEPTH` static beside inline.
+`type_traits.h` left nine variable templates without `inline`, which gcc gives one copy per
+translation unit, so a module importer and a header includer read different addresses for
+the same trait. `tests/test_modules_identity.cpp` takes that address through the module
+alone, and `test_modules.cpp` compares it against the header address.
 
-**Open questions:** `BUGS.md` B2, B5 and B8. B2 reaches this work through CI, and the
-owner rules it test construction rather than a defect.
+**The generator learned three configuration rules.** It used to emit an export list for the
+configuration it happened to parse in, so any declaration a header hides under another
+configuration became an unguarded export. Each rule carries a selftest.
+
+| Rule | Reaches | Mechanism |
+|---|---|---|
+| a macro a define can toggle | `RPP_ENABLE_UNICODE`, `!RPP_BARE_METAL` | parse each configuration, guard the difference |
+| a macro no define reaches | `RPP_HAS_COROUTINES` | read the `#if` span the header brackets, and match a declaration by line |
+| an inline namespace | `rpp::literals`, `rpp::duration_literals` | read the `inline` keyword from the header |
+
+The second rule matches by declaration location, not by name text. A text search also
+matched a name a guarded block only mentions, which would have hidden the whole
+`rpp::semaphore` and `rpp::concurrent_queue` classes wherever the macro is 0. Neither
+header carries a module yet, so the L3 layer would have been the first to hit it.
+
+The generator also mishandled two kinds of declaration. An out-of-line member definition
+reached the export list and broke the build. A blanket skip of `UNEXPOSED_DECL` hid every
+variable template. Both tools carry a selftest case for the shape they missed.
+
+**A module can move a declaration.** `rpp::sort` lived in `collections.h`, so `rpp.collections`
+carried it and an importer of `rpp.sort` could not call it. The generic overloads moved to
+`sort.h`, which already declared `contiguous_container`. `collections.h` keeps the two shapes
+only it can offer, the vector overload an explicit `rpp::sort<T>(v)` names, and the
+`element_range` overload whose by-value parameter lets a const view sort its mutable
+elements. Asking which module should carry a name is worth doing per layer.
+
+**Open questions:** `BUGS.md` B2, B5, B6 and B8. B2 and B6 reach this work through CI only.
+B6 costs the most. It failed 6 of the 40 TSAN jobs this branch ran, which is 15 percent per
+job, and 5 TSAN jobs per run puts a red job in more than half of all runs. Every one passed
+every test and failed on the sanitizer exit code alone.
 
 ---
 

--- a/src/rpp/collections.h
+++ b/src/rpp/collections.h
@@ -529,7 +529,28 @@ namespace rpp
 
     /////////////////////////////////////////////////////////////////////////////////////
 
-    // rpp::sort moved to sort.h, so `import rpp.sort;` alone reaches it. This header includes it.
+    // rpp::sort moved to sort.h, so `import rpp.sort;` alone reaches it. These two keep the
+    // shapes only this header could offer: `sort<T>(v)`, and a const view over mutable elements
+
+    /**
+     * @brief Sorts a vector in ascending order
+     * @param v The vector to sort, whose element type an explicit `rpp::sort<T>(v)` may name
+     */
+    template<class T, class A> FINLINE void sort(std::vector<T, A>& v)
+    {
+        rpp::insertion_sort(v.data(), v.size(), [](const T& a, const T& b) { return a < b; });
+    }
+
+    /**
+     * @brief Sorts the elements an element_range views, with a custom comparison
+     * @param v The range, taken by value, so a const range still sorts its mutable elements
+     * @param comparison bool(T a, T b), true when a < b
+     */
+    template<typename T, typename Comparison>
+    FINLINE void sort(element_range<T> v, const Comparison& comparison)
+    {
+        rpp::insertion_sort(v.data(), v.size(), comparison);
+    }
 
     /////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/rpp/collections.h
+++ b/src/rpp/collections.h
@@ -529,22 +529,7 @@ namespace rpp
 
     /////////////////////////////////////////////////////////////////////////////////////
 
-    template<class T, class A> void sort(std::vector<T, A>& v)
-    {
-        rpp::insertion_sort(v.data(), v.size(), [](const T& a, const T& b) { return a < b; });
-    }
-
-    template<typename T, typename Comparison>
-    void sort(std::vector<T>& v, const Comparison& comparison)
-    {
-        rpp::insertion_sort(v.data(), v.size(), comparison);
-    }
-
-    template<typename T, typename Comparison>
-    void sort(element_range<T> v, const Comparison& comparison)
-    {
-        rpp::insertion_sort(v.data(), v.size(), comparison);
-    }
+    // rpp::sort moved to sort.h, so `import rpp.sort;` alone reaches it. This header includes it.
 
     /////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/rpp/math.h
+++ b/src/rpp/math.h
@@ -8,34 +8,34 @@ namespace rpp
 {
     ///////////////////////////////////////////////////////////////////////////////
 
-    constexpr double PI     = 3.14159265358979323846264338327950288;
-    constexpr float  PIf    = 3.14159265358979323846264338327950288f;
-    constexpr double SQRT2  = 1.41421356237309504880;  // sqrt(2)
-    constexpr float  SQRT2f = 1.41421356237309504880f; // sqrt(2)
+    inline constexpr double PI     = 3.14159265358979323846264338327950288;
+    inline constexpr float  PIf    = 3.14159265358979323846264338327950288f;
+    inline constexpr double SQRT2  = 1.41421356237309504880;  // sqrt(2)
+    inline constexpr float  SQRT2f = 1.41421356237309504880f; // sqrt(2)
 
     /** @return Radians from degrees */
-    static constexpr float radf(float degrees)
+    constexpr float radf(float degrees)
     {
         return (degrees * rpp::PIf) / 180.0f; // rads=(degs*PI)/180
     }
     /** @return Radians from degrees */
-    static constexpr double radf(double degrees)
+    constexpr double radf(double degrees)
     {
         return (degrees * rpp::PI) / 180.0; // rads=(degs*PI)/180
     }
     /** @return Degrees from radians */
-    static constexpr float degf(float radians)
+    constexpr float degf(float radians)
     {
         return radians * (180.0f / rpp::PIf); // degs=rads*(180/PI)
     }
     /** @return Degrees from radians */
-    static constexpr double degf(double radians)
+    constexpr double degf(double radians)
     {
         return radians * (180.0 / rpp::PI); // degs=rads*(180/PI)
     }
 
     /** @brief Clamps a value between:  min <= value <= max */
-    template<class T> static constexpr T clamp(const T value, const T min, const T max) 
+    template<class T> constexpr T clamp(const T value, const T min, const T max) 
     {
         return value < min ? min : (value < max ? value : max);
     }
@@ -47,7 +47,7 @@ namespace rpp
      * @param start Starting bound of the linear range
      * @param end Ending bound of the linear range
      */
-    template<class T> static constexpr T lerp(const T position, const T start, const T end)
+    template<class T> constexpr T lerp(const T position, const T start, const T end)
     {
         return start + (end-start)*position;
     }
@@ -63,7 +63,7 @@ namespace rpp
      *         Less than 0 or Greater than 1 if out of bounds
      *         0 if invalid span (end-start)==0
      */
-    template<class T> static constexpr T lerpInverse(const T value, const T start, const T end)
+    template<class T> constexpr T lerpInverse(const T value, const T start, const T end)
     {
         T span = (end - start);
         return span == 0 ? 0 : (value - start) / span;
@@ -72,19 +72,19 @@ namespace rpp
     ///////////////////////////////////////////////////////////////////////////////
 
     /** @return TRUE if abs(value) is very close to 0.0, epsilon controls the threshold */
-    template<class T> static constexpr bool nearlyZero(const T& value, const T epsilon = (T)0.001)
+    template<class T> constexpr bool nearlyZero(const T& value, const T epsilon = (T)0.001)
     {
         return abs(value) <= epsilon;
     }
 
     /** @return TRUE if a and b are very close to being equal, epsilon controls the threshold */
-    template<class T> static constexpr bool almostEqual(const T& a, const T& b, const T epsilon = (T)0.001)
+    template<class T> constexpr bool almostEqual(const T& a, const T& b, const T epsilon = (T)0.001)
     {
         return abs(a - b) <= epsilon;
     }
 
     /** @brief Clamps the value to zero if it is very close to zero */
-    template<class T> static constexpr T clampZero(const T value, const T epsilon = (T)0.001)
+    template<class T> constexpr T clampZero(const T value, const T epsilon = (T)0.001)
     {
         return nearlyZero(value, epsilon) ? 0 : value;
     }

--- a/src/rpp/rpp-atomic_timepoint.cppm
+++ b/src/rpp/rpp-atomic_timepoint.cppm
@@ -1,0 +1,18 @@
+// C++20 module interface unit for <rpp/atomic_timepoint.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "atomic_timepoint.h"
+
+export module rpp.atomic_timepoint;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+export import rpp.timepoint;
+
+export namespace rpp {
+    using rpp::AtomicDuration;
+    using rpp::AtomicTimePoint;
+    using rpp::AtomicTimeSource;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-bitutils.cppm
+++ b/src/rpp/rpp-bitutils.cppm
@@ -1,0 +1,14 @@
+// C++20 module interface unit for <rpp/bitutils.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "bitutils.h"
+
+export module rpp.bitutils;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+
+export namespace rpp {
+    using rpp::bit_array;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-collections.cppm
+++ b/src/rpp/rpp-collections.cppm
@@ -1,0 +1,48 @@
+// C++20 module interface unit for <rpp/collections.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "collections.h"
+
+export module rpp.collections;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.sort;
+
+export namespace rpp {
+    using rpp::element_range;
+    using rpp::range;
+    using rpp::element_type_with_const;
+    using rpp::slice;
+    using rpp::index_range;
+    using rpp::operator+;
+    using rpp::operator-;
+    using rpp::swap;
+    using rpp::pop_back;
+    using rpp::pop_front;
+    using rpp::push_unique;
+    using rpp::erase_item;
+    using rpp::erase_first_if;
+    using rpp::erase_if;
+    using rpp::erase_back_swap;
+    using rpp::erase_item_back_swap;
+    using rpp::erase_back_swap_first_if;
+    using rpp::erase_back_swap_all_if;
+    using rpp::contains;
+    using rpp::append;
+    using rpp::find;
+    using rpp::find_if;
+    using rpp::find_last_if;
+    using rpp::find_smallest;
+    using rpp::find_largest;
+    using rpp::index_of;
+    using rpp::any_of;
+    using rpp::all_of;
+    using rpp::none_of;
+    using rpp::sum_all;
+    using rpp::transform;
+    using rpp::sort;
+    using rpp::operator==;
+    using rpp::operator!=;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-collections.cppm
+++ b/src/rpp/rpp-collections.cppm
@@ -41,7 +41,6 @@ export namespace rpp {
     using rpp::none_of;
     using rpp::sum_all;
     using rpp::transform;
-    using rpp::sort;
     using rpp::operator==;
     using rpp::operator!=;
 }

--- a/src/rpp/rpp-collections.cppm
+++ b/src/rpp/rpp-collections.cppm
@@ -41,6 +41,7 @@ export namespace rpp {
     using rpp::none_of;
     using rpp::sum_all;
     using rpp::transform;
+    using rpp::sort;
     using rpp::operator==;
     using rpp::operator!=;
 }

--- a/src/rpp/rpp-delegate.cppm
+++ b/src/rpp/rpp-delegate.cppm
@@ -1,0 +1,18 @@
+// C++20 module interface unit for <rpp/delegate.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "delegate.h"
+
+export module rpp.delegate;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+
+export namespace rpp {
+    using rpp::delegate;
+    using rpp::multicast_delegate;
+    using rpp::multicast_fwd;
+    using rpp::multicast_fwd_t;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-endian.cppm
+++ b/src/rpp/rpp-endian.cppm
@@ -1,0 +1,26 @@
+// C++20 module interface unit for <rpp/endian.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "endian.h"
+
+export module rpp.endian;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+
+export namespace rpp {
+    using rpp::writeBEU16;
+    using rpp::writeBEU32;
+    using rpp::writeBEU64;
+    using rpp::readBEU16;
+    using rpp::readBEU32;
+    using rpp::readBEU64;
+    using rpp::writeLEU16;
+    using rpp::writeLEU32;
+    using rpp::writeLEU64;
+    using rpp::readLEU16;
+    using rpp::readLEU32;
+    using rpp::readLEU64;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-future_types.cppm
+++ b/src/rpp/rpp-future_types.cppm
@@ -1,0 +1,23 @@
+// C++20 module interface unit for <rpp/future_types.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "future_types.h"
+
+export module rpp.future_types;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+
+export namespace rpp {
+    using rpp::cfuture;
+    using rpp::coro_handle;
+    using rpp::suspend_never;
+    using rpp::suspend_always;
+    using rpp::IsFuture;
+    using rpp::NotFuture;
+    using rpp::IsFunction;
+    using rpp::IsFunctionReturningFuture;
+    using rpp::IsFunctionNotReturningFuture;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-future_types.cppm
+++ b/src/rpp/rpp-future_types.cppm
@@ -11,13 +11,15 @@ export import rpp.config;
 
 export namespace rpp {
     using rpp::cfuture;
-    using rpp::coro_handle;
-    using rpp::suspend_never;
-    using rpp::suspend_always;
     using rpp::IsFuture;
     using rpp::NotFuture;
     using rpp::IsFunction;
     using rpp::IsFunctionReturningFuture;
     using rpp::IsFunctionNotReturningFuture;
+#if RPP_HAS_COROUTINES
+    using rpp::coro_handle;
+    using rpp::suspend_never;
+    using rpp::suspend_always;
+#endif
 }
 // GENERATED EXPORTS END

--- a/src/rpp/rpp-math.cppm
+++ b/src/rpp/rpp-math.cppm
@@ -1,0 +1,26 @@
+// C++20 module interface unit for <rpp/math.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "math.h"
+
+export module rpp.math;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.minmax;
+
+export namespace rpp {
+    using rpp::PI;
+    using rpp::PIf;
+    using rpp::SQRT2;
+    using rpp::SQRT2f;
+    using rpp::radf;
+    using rpp::degf;
+    using rpp::clamp;
+    using rpp::lerp;
+    using rpp::lerpInverse;
+    using rpp::nearlyZero;
+    using rpp::almostEqual;
+    using rpp::clampZero;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-predicates.cppm
+++ b/src/rpp/rpp-predicates.cppm
@@ -1,0 +1,16 @@
+// C++20 module interface unit for <rpp/predicates.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "predicates.h"
+
+export module rpp.predicates;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+
+export namespace rpp {
+    using rpp::IsCallable;
+    using rpp::IsPredicate;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-proc_utils.cppm
+++ b/src/rpp/rpp-proc_utils.cppm
@@ -1,0 +1,18 @@
+// C++20 module interface unit for <rpp/proc_utils.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "proc_utils.h"
+
+export module rpp.proc_utils;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+
+export namespace rpp {
+    using rpp::proc_mem_info;
+    using rpp::proc_current_mem_used;
+    using rpp::cpu_usage_info;
+    using rpp::proc_total_cpu_usage;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-sort.cppm
+++ b/src/rpp/rpp-sort.cppm
@@ -1,0 +1,18 @@
+// C++20 module interface unit for <rpp/sort.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "sort.h"
+
+export module rpp.sort;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+
+export namespace rpp {
+    using rpp::sort_comparison;
+    using rpp::contiguous_container;
+    using rpp::container_element_t;
+    using rpp::insertion_sort;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-sort.cppm
+++ b/src/rpp/rpp-sort.cppm
@@ -14,5 +14,6 @@ export namespace rpp {
     using rpp::contiguous_container;
     using rpp::container_element_t;
     using rpp::insertion_sort;
+    using rpp::sort;
 }
 // GENERATED EXPORTS END

--- a/src/rpp/rpp-source_loc.cppm
+++ b/src/rpp/rpp-source_loc.cppm
@@ -1,0 +1,15 @@
+// C++20 module interface unit for <rpp/source_loc.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "source_loc.h"
+
+export module rpp.source_loc;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+
+export namespace rpp {
+    using rpp::source_loc;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-stack_trace.cppm
+++ b/src/rpp/rpp-stack_trace.cppm
@@ -1,0 +1,27 @@
+// C++20 module interface unit for <rpp/stack_trace.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "stack_trace.h"
+
+export module rpp.stack_trace;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+export import rpp.strview;
+
+export namespace rpp {
+    using rpp::CallstackEntry;
+    using rpp::get_address_info;
+    using rpp::CALLSTACK_MAX_DEPTH;
+    using rpp::get_callstack;
+    using rpp::ThreadCallstack;
+    using rpp::get_all_callstacks;
+    using rpp::format_trace;
+    using rpp::stack_trace;
+    using rpp::print_trace;
+    using rpp::error_with_trace;
+    using rpp::traced_exception;
+    using rpp::register_segfault_tracer;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-threads.cppm
+++ b/src/rpp/rpp-threads.cppm
@@ -1,0 +1,22 @@
+// C++20 module interface unit for <rpp/threads.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "threads.h"
+
+export module rpp.threads;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+export import rpp.strview;
+
+export namespace rpp {
+    using rpp::set_this_thread_name;
+    using rpp::get_this_thread_name;
+    using rpp::get_thread_name;
+    using rpp::get_thread_id;
+    using rpp::get_process_id;
+    using rpp::num_physical_cores;
+    using rpp::yield;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-threads.cppm
+++ b/src/rpp/rpp-threads.cppm
@@ -11,12 +11,14 @@ export import rpp.config;
 export import rpp.strview;
 
 export namespace rpp {
+    using rpp::yield;
+#if !RPP_BARE_METAL
     using rpp::set_this_thread_name;
     using rpp::get_this_thread_name;
     using rpp::get_thread_name;
     using rpp::get_thread_id;
     using rpp::get_process_id;
     using rpp::num_physical_cores;
-    using rpp::yield;
+#endif
 }
 // GENERATED EXPORTS END

--- a/src/rpp/rpp-timepoint.cppm
+++ b/src/rpp/rpp-timepoint.cppm
@@ -1,0 +1,47 @@
+// C++20 module interface unit for <rpp/timepoint.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "timepoint.h"
+
+export module rpp.timepoint;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+
+export using ::time_now_seconds;
+
+export namespace rpp {
+    using rpp::sleep_ms;
+    using rpp::sleep_us;
+    using rpp::sleep_ns;
+    using rpp::Duration;
+    using rpp::TimePoint;
+    using rpp::sleep_for;
+    using rpp::sleep_until;
+    using rpp::ClockType;
+    using rpp::MILLIS_PER_SEC;
+    using rpp::MICROS_PER_SEC;
+    using rpp::NANOS_PER_SEC;
+    using rpp::NANOS_PER_MILLI;
+    using rpp::NANOS_PER_MICRO;
+    using rpp::NANOS_PER_YEAR;
+    using rpp::NANOS_PER_DAY;
+    using rpp::NANOS_PER_HOUR;
+    using rpp::NANOS_PER_MINUTE;
+    using rpp::seconds_f;
+    using rpp::seconds;
+    using rpp::millis_f;
+    using rpp::millis;
+    using rpp::micros_f;
+    using rpp::micros;
+    using rpp::nanos;
+}
+
+export namespace rpp::duration_literals {
+    using rpp::duration_literals::operator""_s;
+    using rpp::duration_literals::operator""_ms;
+    using rpp::duration_literals::operator""_us;
+    using rpp::duration_literals::operator""_ns;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-timepoint.cppm
+++ b/src/rpp/rpp-timepoint.cppm
@@ -38,7 +38,7 @@ export namespace rpp {
     using rpp::nanos;
 }
 
-export namespace rpp::duration_literals {
+export namespace rpp::inline duration_literals {
     using rpp::duration_literals::operator""_s;
     using rpp::duration_literals::operator""_ms;
     using rpp::duration_literals::operator""_us;

--- a/src/rpp/rpp-timer.cppm
+++ b/src/rpp/rpp-timer.cppm
@@ -1,0 +1,18 @@
+// C++20 module interface unit for <rpp/timer.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "timer.h"
+
+export module rpp.timer;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+export import rpp.timepoint;
+
+export namespace rpp {
+    using rpp::Timer;
+    using rpp::StopWatch;
+    using rpp::ScopedPerfTimer;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-traits.cppm
+++ b/src/rpp/rpp-traits.cppm
@@ -1,0 +1,17 @@
+// C++20 module interface unit for <rpp/traits.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "traits.h"
+
+export module rpp.traits;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+
+export namespace rpp {
+    using rpp::function_traits;
+    using rpp::first_arg_type;
+    using rpp::cont_return_t;
+    using rpp::task_return_t;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-type_traits.cppm
+++ b/src/rpp/rpp-type_traits.cppm
@@ -1,0 +1,38 @@
+// C++20 module interface unit for <rpp/type_traits.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "type_traits.h"
+
+export module rpp.type_traits;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+
+export namespace rpp {
+    using rpp::is_detected;
+    using rpp::is_detected_v;
+    using rpp::std_to_string_expression;
+    using rpp::to_string_expression;
+    using rpp::to_string_memb_expression;
+    using rpp::get_memb_expression;
+    using rpp::set_memb_expression;
+    using rpp::has_std_to_string;
+    using rpp::has_to_string;
+    using rpp::has_to_string_memb;
+    using rpp::has_get_memb;
+    using rpp::has_set_memb;
+    using rpp::has_begin_expression;
+    using rpp::has_end_expression;
+    using rpp::has_size_expression;
+    using rpp::has_c_str_expression;
+    using rpp::is_iterable;
+    using rpp::is_stringlike;
+    using rpp::is_container;
+}
+
+export namespace rpp::detail {
+    using rpp::detail::void_t;
+    using rpp::detail::is_detected;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-type_traits.cppm
+++ b/src/rpp/rpp-type_traits.cppm
@@ -12,12 +12,10 @@ export import rpp.config;
 export namespace rpp {
     using rpp::is_detected;
     using rpp::is_detected_v;
-    using rpp::std_to_string_expression;
     using rpp::to_string_expression;
     using rpp::to_string_memb_expression;
     using rpp::get_memb_expression;
     using rpp::set_memb_expression;
-    using rpp::has_std_to_string;
     using rpp::has_to_string;
     using rpp::has_to_string_memb;
     using rpp::has_get_memb;
@@ -29,6 +27,10 @@ export namespace rpp {
     using rpp::is_iterable;
     using rpp::is_stringlike;
     using rpp::is_container;
+#if !RPP_BARE_METAL
+    using rpp::std_to_string_expression;
+    using rpp::has_std_to_string;
+#endif
 }
 
 export namespace rpp::detail {

--- a/src/rpp/rpp-vec.cppm
+++ b/src/rpp/rpp-vec.cppm
@@ -1,0 +1,50 @@
+// C++20 module interface unit for <rpp/vec.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "vec.h"
+
+export module rpp.vec;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.math;
+export import rpp.strview;
+
+export namespace rpp {
+    using rpp::Vector2;
+    using rpp::vec2;
+    using rpp::operator+;
+    using rpp::operator-;
+    using rpp::operator*;
+    using rpp::operator/;
+    using rpp::clamp;
+    using rpp::lerp;
+    using rpp::Vector2d;
+    using rpp::vec2d;
+    using rpp::Point;
+    using rpp::point2;
+    using rpp::RectF;
+    using rpp::Rect;
+    using rpp::Recti;
+    using rpp::Vector3d;
+    using rpp::Vector3;
+    using rpp::vec3;
+    using rpp::vec3d;
+    using rpp::AngleAxis;
+    using rpp::Matrix3;
+    using rpp::Matrix4;
+    using rpp::Vector4;
+    using rpp::vec4;
+    using rpp::rect;
+    using rpp::_Matrix3RowVis;
+    using rpp::_Matrix4RowVis;
+    using rpp::PerspectiveViewport;
+    using rpp::Color;
+    using rpp::Color3;
+    using rpp::IdVector3;
+    using rpp::BoundingBox;
+    using rpp::BoundingSphere;
+    using rpp::Ray;
+    using rpp::to_string;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/sort.h
+++ b/src/rpp/sort.h
@@ -88,4 +88,33 @@ namespace rpp
     {
         insertion_sort(container.data(), container.size(), comparison);
     }
+
+    /**
+     * @brief Sorts a contiguous container in ascending order
+     * @param container Any container with data(), size() and operator[], such as std::vector
+     */
+    template<typename Container>
+    FINLINE void sort(Container&& container)
+        #if RPP_HAS_CXX20
+            requires contiguous_container<Container>
+        #endif
+    {
+        insertion_sort(container.data(), container.size(),
+                       [](const auto& a, const auto& b) { return a < b; });
+    }
+
+    /**
+     * @brief Sorts a contiguous container with a custom comparison
+     * @param container Any container with data(), size() and operator[], such as std::vector
+     * @param comparison bool(T a, T b), true when a < b
+     */
+    template<typename Container, typename Comparison>
+    FINLINE void sort(Container&& container, const Comparison& comparison)
+        #if RPP_HAS_CXX20
+            requires contiguous_container<Container> &&
+                     sort_comparison<container_element_t<Container>, Comparison>
+        #endif
+    {
+        insertion_sort(container.data(), container.size(), comparison);
+    }
 }

--- a/src/rpp/stack_trace.h
+++ b/src/rpp/stack_trace.h
@@ -46,7 +46,7 @@ namespace rpp
     RPPAPI CallstackEntry get_address_info(uint64_t addr) noexcept;
 
     // absolute limit for callstack depth
-    static inline constexpr size_t CALLSTACK_MAX_DEPTH = 256u;
+    inline constexpr size_t CALLSTACK_MAX_DEPTH = 256u;
 
     /**
      * @brief Walks the stack and returns a list of callstack addresses.

--- a/src/rpp/timepoint.h
+++ b/src/rpp/timepoint.h
@@ -91,15 +91,15 @@ namespace rpp
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
-    static constexpr int64 MILLIS_PER_SEC = 1'000LL;
-    static constexpr int64 MICROS_PER_SEC = 1'000'000LL;
-    static constexpr int64 NANOS_PER_SEC  = 1'000'000'000LL;
-    static constexpr int64 NANOS_PER_MILLI = 1'000'000LL;
-    static constexpr int64 NANOS_PER_MICRO = 1'000LL;
-    static constexpr int64 NANOS_PER_YEAR   = 31'557'600'000'000'000LL;
-    static constexpr int64 NANOS_PER_DAY    = 86'400'000'000'000LL;
-    static constexpr int64 NANOS_PER_HOUR   = 3'600'000'000'000LL;
-    static constexpr int64 NANOS_PER_MINUTE = 60'000'000'000LL;
+    inline constexpr int64 MILLIS_PER_SEC = 1'000LL;
+    inline constexpr int64 MICROS_PER_SEC = 1'000'000LL;
+    inline constexpr int64 NANOS_PER_SEC  = 1'000'000'000LL;
+    inline constexpr int64 NANOS_PER_MILLI = 1'000'000LL;
+    inline constexpr int64 NANOS_PER_MICRO = 1'000LL;
+    inline constexpr int64 NANOS_PER_YEAR   = 31'557'600'000'000'000LL;
+    inline constexpr int64 NANOS_PER_DAY    = 86'400'000'000'000LL;
+    inline constexpr int64 NANOS_PER_HOUR   = 3'600'000'000'000LL;
+    inline constexpr int64 NANOS_PER_MINUTE = 60'000'000'000LL;
 
     /**
      * @brief New Duration API for TimePoint arithmetics

--- a/src/rpp/traits.h
+++ b/src/rpp/traits.h
@@ -10,50 +10,47 @@
 
 namespace rpp
 {
-    namespace
-    {
-        template<typename T>
-        struct function_traits : function_traits<decltype(&T::operator())> {
-        };
+    template<typename T>
+    struct function_traits : function_traits<decltype(&T::operator())> {
+    };
 
-        template<typename R, typename... Args>
-        struct function_traits<R(Args...)> { // function type
-            using ret_type  = R;
-            using arg_types = std::tuple<Args...>;
-        };
-        
-        template<typename R, typename... Args>
-        struct function_traits<R (*)(Args...)> { // function pointer
-            using ret_type  = R;
-            using arg_types = std::tuple<Args...>;
-        };
-
-        // template<typename R, typename... Args>
-        // struct function_traits<std::function<R(Args...)>> {
-        //     using ret_type  = R;
-        //     using arg_types = std::tuple<Args...>;
-        // };
-
-        template<typename T, typename R, typename... Args>
-        struct function_traits<R (T::*)(Args...)> { // member func ptr
-            using ret_type  = R;
-            using arg_types = std::tuple<Args...>;
-        };
-
-        template<typename T, typename R, typename... Args>
-        struct function_traits<R (T::*)(Args...) const> {  // const member func ptr
-            using ret_type  = R;
-            using arg_types = std::tuple<Args...>;
-        };
-
-        template<typename T>
-        using first_arg_type = typename std::tuple_element<0, typename function_traits<T>::arg_types>::type;
+    template<typename R, typename... Args>
+    struct function_traits<R(Args...)> { // function type
+        using ret_type  = R;
+        using arg_types = std::tuple<Args...>;
+    };
     
-        // return type of a continuation Task functor which takes argument T
-        template<typename Task, typename T>
-        using cont_return_t = std::decay_t<decltype(std::declval<Task>()(std::declval<T>()))>;
+    template<typename R, typename... Args>
+    struct function_traits<R (*)(Args...)> { // function pointer
+        using ret_type  = R;
+        using arg_types = std::tuple<Args...>;
+    };
 
-        template<typename Task>
-        using task_return_t = std::decay_t<decltype(std::declval<Task>()())>;
-    }
+    // template<typename R, typename... Args>
+    // struct function_traits<std::function<R(Args...)>> {
+    //     using ret_type  = R;
+    //     using arg_types = std::tuple<Args...>;
+    // };
+
+    template<typename T, typename R, typename... Args>
+    struct function_traits<R (T::*)(Args...)> { // member func ptr
+        using ret_type  = R;
+        using arg_types = std::tuple<Args...>;
+    };
+
+    template<typename T, typename R, typename... Args>
+    struct function_traits<R (T::*)(Args...) const> {  // const member func ptr
+        using ret_type  = R;
+        using arg_types = std::tuple<Args...>;
+    };
+
+    template<typename T>
+    using first_arg_type = typename std::tuple_element<0, typename function_traits<T>::arg_types>::type;
+    
+    // return type of a continuation Task functor which takes argument T
+    template<typename Task, typename T>
+    using cont_return_t = std::decay_t<decltype(std::declval<Task>()(std::declval<T>()))>;
+
+    template<typename Task>
+    using task_return_t = std::decay_t<decltype(std::declval<Task>()())>;
 }

--- a/src/rpp/type_traits.h
+++ b/src/rpp/type_traits.h
@@ -26,7 +26,7 @@ namespace rpp
     using is_detected = detail::is_detected<detail::void_t<>, Operation, Arguments...>;
 
     template<template<class...> class Operation, typename... Arguments>
-    constexpr bool is_detected_v = detail::is_detected<detail::void_t<>, Operation, Arguments...>::value;
+    inline constexpr bool is_detected_v = detail::is_detected<detail::void_t<>, Operation, Arguments...>::value;
 
 #if !RPP_BARE_METAL
     template<class T> using std_to_string_expression  = decltype(std::to_string(std::declval<T>()));
@@ -37,24 +37,24 @@ namespace rpp
     template<class T, class U> using set_memb_expression = decltype(std::declval<T>().set(std::declval<U>()));
 
 #if !RPP_BARE_METAL
-    template<class T> constexpr bool has_std_to_string  = is_detected_v<std_to_string_expression, T>;
+    template<class T> inline constexpr bool has_std_to_string  = is_detected_v<std_to_string_expression, T>;
 #endif
-    template<class T> constexpr bool has_to_string      = is_detected_v<to_string_expression, T>;
-    template<class T> constexpr bool has_to_string_memb = is_detected_v<to_string_memb_expression, T>;
-    template<class T> constexpr bool has_get_memb       = is_detected_v<get_memb_expression, T>;
-    template<class T, class U> constexpr bool has_set_memb = is_detected_v<set_memb_expression, T, U>;
+    template<class T> inline constexpr bool has_to_string      = is_detected_v<to_string_expression, T>;
+    template<class T> inline constexpr bool has_to_string_memb = is_detected_v<to_string_memb_expression, T>;
+    template<class T> inline constexpr bool has_get_memb       = is_detected_v<get_memb_expression, T>;
+    template<class T, class U> inline constexpr bool has_set_memb = is_detected_v<set_memb_expression, T, U>;
 
     template<class T> using has_begin_expression  = decltype(std::declval<T>().begin());
     template<class T> using has_end_expression    = decltype(std::declval<T>().end());
     template<class T> using has_size_expression   = decltype(std::declval<T>().size());
     template<class T> using has_c_str_expression  = decltype(std::declval<T>().c_str());
 
-    template<class T> constexpr bool is_iterable = is_detected_v<has_begin_expression, T>
+    template<class T> inline constexpr bool is_iterable = is_detected_v<has_begin_expression, T>
                                                 && is_detected_v<has_end_expression, T>;
 
-    template<class T> constexpr bool is_stringlike = is_detected_v<has_c_str_expression, T>;
+    template<class T> inline constexpr bool is_stringlike = is_detected_v<has_c_str_expression, T>;
 
-    template<class T> constexpr bool is_container = is_iterable<T>
+    template<class T> inline constexpr bool is_container = is_iterable<T>
                                                  && is_detected_v<has_size_expression, T>
                                                  && !is_stringlike<T>;
 

--- a/tests/module_consumer/CMakeLists.txt
+++ b/tests/module_consumer/CMakeLists.txt
@@ -24,9 +24,9 @@ add_executable(RppMinmaxModuleOnly minmax_module_only.cpp)
 target_include_directories(RppMinmaxModuleOnly PRIVATE ${MAMA_INCLUDES})
 mama_target_modules(RppMinmaxModuleOnly)
 
-# <rpp/tests.h> also includes type_traits.h, source_loc.h and future_types.h
-add_executable(RppL1ModuleOnly l1_module_only.cpp)
-target_include_directories(RppL1ModuleOnly PRIVATE ${MAMA_INCLUDES})
-mama_target_modules(RppL1ModuleOnly)
+# <rpp/tests.h> also includes type_traits.h, source_loc.h, future_types.h and sprint.h
+add_executable(RppMaskedModuleOnly masked_module_only.cpp)
+target_include_directories(RppMaskedModuleOnly PRIVATE ${MAMA_INCLUDES})
+mama_target_modules(RppMaskedModuleOnly)
 target_link_libraries(RppModuleConsumer PRIVATE ${MAMA_LIBS})
 install(TARGETS RppModuleConsumer RUNTIME DESTINATION bin)

--- a/tests/module_consumer/CMakeLists.txt
+++ b/tests/module_consumer/CMakeLists.txt
@@ -23,5 +23,10 @@ mama_target_modules(RppConfigModuleOnly)
 add_executable(RppMinmaxModuleOnly minmax_module_only.cpp)
 target_include_directories(RppMinmaxModuleOnly PRIVATE ${MAMA_INCLUDES})
 mama_target_modules(RppMinmaxModuleOnly)
+
+# <rpp/tests.h> also includes type_traits.h, source_loc.h and future_types.h
+add_executable(RppL1ModuleOnly l1_module_only.cpp)
+target_include_directories(RppL1ModuleOnly PRIVATE ${MAMA_INCLUDES})
+mama_target_modules(RppL1ModuleOnly)
 target_link_libraries(RppModuleConsumer PRIVATE ${MAMA_LIBS})
 install(TARGETS RppModuleConsumer RUNTIME DESTINATION bin)

--- a/tests/module_consumer/CMakeLists.txt
+++ b/tests/module_consumer/CMakeLists.txt
@@ -28,5 +28,10 @@ mama_target_modules(RppMinmaxModuleOnly)
 add_executable(RppMaskedModuleOnly masked_module_only.cpp)
 target_include_directories(RppMaskedModuleOnly PRIVATE ${MAMA_INCLUDES})
 mama_target_modules(RppMaskedModuleOnly)
+
+# rpp::sort has to reach an importer of rpp.sort, without rpp.collections beside it
+add_executable(RppSortModuleOnly sort_module_only.cpp)
+target_include_directories(RppSortModuleOnly PRIVATE ${MAMA_INCLUDES})
+mama_target_modules(RppSortModuleOnly)
 target_link_libraries(RppModuleConsumer PRIVATE ${MAMA_LIBS})
 install(TARGETS RppModuleConsumer RUNTIME DESTINATION bin)

--- a/tests/module_consumer/l1_module_only.cpp
+++ b/tests/module_consumer/l1_module_only.cpp
@@ -1,0 +1,31 @@
+// Imports the three L1 modules that <rpp/tests.h> masks, with no header, so the build
+// fails if any of them drops an export. tests/test_modules.cpp cannot prove these three.
+#ifdef MAMA_HAS_MODULES
+#include <string>
+#include <vector>
+
+import rpp.type_traits; // includes come first, the imports go last
+import rpp.source_loc;
+import rpp.future_types;
+
+int main()
+{
+    // type_traits: the alias templates and the variable templates that read them
+    bool detected = rpp::is_detected_v<rpp::has_size_expression, std::string>
+                 && rpp::is_stringlike<std::string>
+                 && rpp::is_container<std::vector<int>>
+                 && rpp::is_iterable<std::vector<int>>;
+
+    // source_loc: the type carries the call site
+    constexpr rpp::source_loc loc { "l1_module_only.cpp", "main", 21 };
+    bool located = loc.line() == 21 && loc.function_name() != nullptr;
+
+    // future_types: the concepts hold for a plain function
+    auto plain = [] { return 1; };
+    bool typed = rpp::IsFunction<decltype(plain)> && rpp::NotFuture<int>;
+
+    return (detected && located && typed) ? 0 : 1;
+}
+#else
+int main() { return 0; } // the header build does not exercise the module
+#endif

--- a/tests/module_consumer/masked_module_only.cpp
+++ b/tests/module_consumer/masked_module_only.cpp
@@ -1,5 +1,5 @@
-// Imports the three L1 modules that <rpp/tests.h> masks, with no header, so the build
-// fails if any of them drops an export. tests/test_modules.cpp cannot prove these three.
+// Imports the modules that <rpp/tests.h> masks, with no header, so the build fails if any
+// of them drops an export. tests/test_modules.cpp cannot prove these three.
 #ifdef MAMA_HAS_MODULES
 #include <string>
 #include <vector>
@@ -17,8 +17,8 @@ int main()
                  && rpp::is_iterable<std::vector<int>>;
 
     // source_loc: the type carries the call site
-    constexpr rpp::source_loc loc { "l1_module_only.cpp", "main", 21 };
-    bool located = loc.line() == 21 && loc.function_name() != nullptr;
+    constexpr rpp::source_loc loc { "masked_module_only.cpp", "main", 22 };
+    bool located = loc.line() == 22 && loc.function_name() != nullptr;
 
     // future_types: the concepts hold for a plain function
     auto plain = [] { return 1; };

--- a/tests/module_consumer/masked_module_only.cpp
+++ b/tests/module_consumer/masked_module_only.cpp
@@ -1,5 +1,5 @@
 // Imports the modules that <rpp/tests.h> masks, with no header, so the build fails if any
-// of them drops an export. tests/test_modules.cpp cannot prove these three.
+// of them drops an export. tests/test_modules.cpp cannot prove these four.
 #ifdef MAMA_HAS_MODULES
 #include <string>
 #include <vector>
@@ -7,6 +7,7 @@
 import rpp.type_traits; // includes come first, the imports go last
 import rpp.source_loc;
 import rpp.future_types;
+import rpp.math;
 
 int main()
 {
@@ -24,7 +25,11 @@ int main()
     auto plain = [] { return 1; };
     bool typed = rpp::IsFunction<decltype(plain)> && rpp::NotFuture<int>;
 
-    return (detected && located && typed) ? 0 : 1;
+    // math: the constants and the functions both come from the module
+    bool numeric = rpp::clamp(5, 0, 3) == 3 && rpp::lerp(0.5, 30.0, 60.0) == 45.0
+                && rpp::nearlyZero(0.0001) && rpp::PI > 3.14;
+
+    return (detected && located && typed && numeric) ? 0 : 1;
 }
 #else
 int main() { return 0; } // the header build does not exercise the module

--- a/tests/module_consumer/sort_module_only.cpp
+++ b/tests/module_consumer/sort_module_only.cpp
@@ -1,0 +1,26 @@
+// Imports rpp.sort alone, with no header and no rpp.collections, so the build fails if
+// rpp::sort stops reaching an importer of the module its name names.
+#ifdef MAMA_HAS_MODULES
+#include <vector>
+
+import rpp.sort; // includes come first, the import goes last
+
+int main()
+{
+    std::vector<int> v { 4, 1, 3 };
+    rpp::sort(v);
+    bool ascending = v[0] == 1 && v[1] == 3 && v[2] == 4;
+
+    rpp::sort(v, [](int a, int b) { return a > b; });
+    bool descending = v[0] == 4 && v[2] == 1;
+
+    // the pointer overload and the container overload both come from this module
+    int raw[3] { 9, 7, 8 };
+    rpp::insertion_sort(raw, 3, [](int a, int b) { return a < b; });
+    bool sorted_raw = raw[0] == 7 && raw[2] == 9;
+
+    return (ascending && descending && sorted_raw) ? 0 : 1;
+}
+#else
+int main() { return 0; } // the header build does not exercise the module
+#endif

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -30,6 +30,9 @@ import rpp.threads;
 import rpp.timer;
 import rpp.vec;
 
+// test_modules_identity.cpp takes this address through the module and includes no rpp header
+const void* module_is_container_addr() noexcept;
+
 TestImpl(test_modules)
 {
     TestInit(test_modules)
@@ -115,6 +118,13 @@ TestImpl(test_modules)
         bits.set(3);
         AssertThat(bits.isSet(3), true);
         AssertThat(bits.isSet(4), false);
+    }
+
+    // a variable template needs `inline`, or gcc gives the module and the header one copy each
+    TestCase(type_traits_variable_template_is_one_entity)
+    {
+        const void* header = &rpp::is_container<std::vector<int>>;
+        AssertThat(module_is_container_addr() == header, true);
     }
 
     TestCase(traits_module_carries_the_whole_surface)

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -14,6 +14,15 @@ import rpp.strview;   // includes come first, the import goes last
 import rpp.debugging;
 import rpp.obfuscated_string;
 import rpp.scopeguard;
+import rpp.bitutils;
+import rpp.traits;
+import rpp.endian;
+import rpp.predicates;
+import rpp.sort;
+import rpp.proc_utils;
+import rpp.math;
+import rpp.timepoint;
+import rpp.delegate;
 
 TestImpl(test_modules)
 {
@@ -89,6 +98,95 @@ TestImpl(test_modules)
             AssertThat(calls, 0);
         }
         AssertThat(calls, 1); // the guard ran when it left the scope
+    }
+
+    // No case below includes a header, so the L1 module alone carries the surface.
+    // <rpp/tests.h> masks type_traits, source_loc and future_types, see l1_module_only.cpp
+
+    TestCase(bitutils_module_carries_the_whole_surface)
+    {
+        rpp::bit_array bits{ 16 };
+        bits.set(3);
+        AssertThat(bits.isSet(3), true);
+        AssertThat(bits.isSet(4), false);
+    }
+
+    TestCase(traits_module_carries_the_whole_surface)
+    {
+        using Fn = int(*)(double);
+        static_assert(std::is_same_v<rpp::function_traits<Fn>::ret_type, int>);
+        static_assert(std::is_same_v<rpp::first_arg_type<Fn>, double>);
+        AssertThat(sizeof(rpp::function_traits<Fn>), sizeof(rpp::function_traits<Fn>));
+    }
+
+    TestCase(endian_module_carries_the_whole_surface)
+    {
+        uint8_t buf[8] = {};
+        rpp::writeBEU32(buf, 0x01020304u);
+        AssertThat(rpp::readBEU32(buf), 0x01020304u);
+        rpp::writeLEU16(buf, uint16_t(0xBEEF));
+        AssertThat(rpp::readLEU16(buf), uint16_t(0xBEEF));
+    }
+
+    TestCase(predicates_module_carries_the_whole_surface)
+    {
+        auto yes = []{ return true; };
+        static_assert(rpp::IsCallable<decltype(yes)>);
+        static_assert(rpp::IsPredicate<decltype(yes)>);
+        AssertThat(yes(), true);
+    }
+
+    TestCase(sort_module_carries_the_whole_surface)
+    {
+        int values[5] = { 4, 2, 5, 1, 3 };
+        rpp::insertion_sort(values, 5, [](int a, int b) { return a < b; });
+        AssertThat(values[0], 1);
+        AssertThat(values[4], 5);
+        static_assert(std::is_same_v<rpp::container_element_t<std::string>, char>);
+    }
+
+    TestCase(proc_utils_module_carries_the_whole_surface)
+    {
+        rpp::proc_mem_info mem = rpp::proc_current_mem_used();
+        AssertGreater(mem.virtual_size, 0u);
+        rpp::cpu_usage_info cpu = rpp::proc_total_cpu_usage();
+        AssertGreaterOrEqual(cpu.cpu_time_us, 0);
+    }
+
+    TestCase(math_module_carries_the_whole_surface)
+    {
+        AssertThat(rpp::clamp(5, 0, 3), 3);
+        AssertThat(rpp::lerp(0.5, 30.0, 60.0), 45.0);
+        AssertThat(rpp::lerpInverse(45.0, 30.0, 60.0), 0.5);
+        AssertThat(rpp::nearlyZero(0.0001), true);
+        AssertThat(rpp::almostEqual(1.0, 1.0001), true);
+        AssertGreater(rpp::PI, 3.14);
+        AssertThat(rpp::degf(rpp::radf(90.0f)), 90.0f);
+    }
+
+    TestCase(timepoint_module_carries_the_whole_surface)
+    {
+        using namespace rpp::duration_literals;
+        rpp::Duration d = rpp::millis(250);
+        AssertThat(d.millis(), 250);
+        AssertThat((1_s).seconds(), 1);
+        AssertThat(rpp::NANOS_PER_SEC, 1'000'000'000LL);
+        rpp::TimePoint start = rpp::TimePoint::now();
+        rpp::sleep_ms(1);
+        AssertGreaterOrEqual((rpp::TimePoint::now() - start).nsec, 0);
+    }
+
+    TestCase(delegate_module_carries_the_whole_surface)
+    {
+        int calls = 0;
+        rpp::delegate<void(int)> d = [&](int n) { calls += n; };
+        d(2);
+        AssertThat(calls, 2);
+
+        rpp::multicast_delegate<int> m;
+        m += [&](int n) { calls += n; };
+        m(3);
+        AssertThat(calls, 5);
     }
 };
 

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -23,6 +23,12 @@ import rpp.proc_utils;
 import rpp.math;
 import rpp.timepoint;
 import rpp.delegate;
+import rpp.atomic_timepoint;
+import rpp.collections;
+import rpp.stack_trace;
+import rpp.threads;
+import rpp.timer;
+import rpp.vec;
 
 TestImpl(test_modules)
 {
@@ -187,6 +193,68 @@ TestImpl(test_modules)
         m += [&](int n) { calls += n; };
         m(3);
         AssertThat(calls, 5);
+    }
+
+    // L2. <rpp/tests.h> masks sprint, so masked_module_only.cpp covers that one.
+
+    TestCase(atomic_timepoint_module_carries_the_whole_surface)
+    {
+        rpp::AtomicDuration d;
+        d.store(rpp::millis(40));
+        AssertThat(d.load().millis(), 40);
+        rpp::AtomicTimePoint t;
+        t.store(rpp::TimePoint::now());
+        AssertThat(t.load().is_valid(), true);
+    }
+
+    TestCase(collections_module_carries_the_whole_surface)
+    {
+        std::vector<int> v { 4, 1, 3 };
+        AssertThat(rpp::contains(v, 3), true);
+        AssertThat(rpp::index_of(v, 1), 1);
+        AssertThat(rpp::sum_all(v), 8);
+        AssertThat(rpp::any_of(v, [](int n) { return n > 3; }), true);
+        rpp::element_range<int> r = rpp::range(v);
+        AssertThat(int(r.size()), 3);
+    }
+
+    TestCase(stack_trace_module_carries_the_whole_surface)
+    {
+        static_assert(rpp::CALLSTACK_MAX_DEPTH == 256u);
+        std::vector<uint64_t> frames = rpp::get_callstack(8);
+        AssertGreater(frames.size(), 0u);
+        AssertGreater(rpp::format_trace("probe", frames.data(), frames.size()).size(), 0u);
+    }
+
+    TestCase(threads_module_carries_the_whole_surface)
+    {
+        AssertGreater(rpp::num_physical_cores(), 0);
+        AssertGreater(rpp::get_thread_id(), 0u);
+        rpp::set_this_thread_name("module_probe");
+        AssertThat(rpp::get_this_thread_name(), std::string{"module_probe"});
+        rpp::yield();
+    }
+
+    TestCase(timer_module_carries_the_whole_surface)
+    {
+        rpp::Timer t;
+        rpp::sleep_ms(1);
+        AssertGreater(t.elapsed_millis(), 0.0);
+        rpp::StopWatch sw;
+        sw.start();
+        sw.stop();
+        AssertGreaterOrEqual(sw.elapsed(), 0.0);
+    }
+
+    TestCase(vec_module_carries_the_whole_surface)
+    {
+        rpp::Vector3 a { 1.0f, 2.0f, 3.0f };
+        rpp::Vector3 b = rpp::Vector3::One();
+        rpp::Vector3 sum = a + b;
+        AssertThat(sum.x, 2.0f);
+        AssertThat(sum.z, 4.0f);
+        rpp::Vector2 p { 3.0f, 4.0f };
+        AssertThat(p.length(), 5.0f);
     }
 };
 

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -182,14 +182,16 @@ TestImpl(test_modules)
 
     TestCase(timepoint_module_carries_the_whole_surface)
     {
-        using namespace rpp::duration_literals;
+        using namespace rpp; // duration_literals is inline, so this alone reaches the operator
         rpp::Duration d = rpp::millis(250);
         AssertThat(d.millis(), 250);
         AssertThat((1_s).seconds(), 1);
+        AssertThat((250_ms).millis(), 250);
         AssertThat(rpp::NANOS_PER_SEC, 1'000'000'000LL);
-        rpp::TimePoint start = rpp::TimePoint::now();
+        // Monotonic never steps back, and TimePoint::now() reads the adjustable realtime clock
+        rpp::TimePoint start = rpp::TimePoint::now(rpp::ClockType::Monotonic);
         rpp::sleep_ms(1);
-        AssertGreaterOrEqual((rpp::TimePoint::now() - start).nsec, 0);
+        AssertGreaterOrEqual((rpp::TimePoint::now(rpp::ClockType::Monotonic) - start).nsec, 0);
     }
 
     TestCase(delegate_module_carries_the_whole_surface)
@@ -238,10 +240,13 @@ TestImpl(test_modules)
 
     TestCase(threads_module_carries_the_whole_surface)
     {
+        // the module hides the six host-only names on bare metal, so the test follows it
+#if !RPP_BARE_METAL
         AssertGreater(rpp::num_physical_cores(), 0);
         AssertGreater(rpp::get_thread_id(), 0u);
         rpp::set_this_thread_name("module_probe");
         AssertThat(rpp::get_this_thread_name(), std::string{"module_probe"});
+#endif
         rpp::yield();
     }
 

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -228,6 +228,13 @@ TestImpl(test_modules)
         AssertThat(rpp::any_of(v, [](int n) { return n > 3; }), true);
         rpp::element_range<int> r = rpp::range(v);
         AssertThat(int(r.size()), 3);
+
+        // collections.h declares rpp::sort, not sort.h, so rpp.collections carries it
+        rpp::sort(v);
+        AssertThat(v[0], 1);
+        AssertThat(v[2], 4);
+        rpp::sort(v, [](int a, int b) { return a > b; });
+        AssertThat(v[0], 4);
     }
 
     TestCase(stack_trace_module_carries_the_whole_surface)

--- a/tests/test_modules_identity.cpp
+++ b/tests/test_modules_identity.cpp
@@ -1,0 +1,14 @@
+/**
+ * Takes a trait address with no rpp header in this translation unit, so the address comes
+ * from the module alone. test_modules.cpp compares it against the header address.
+ */
+#if RPP_BUILD_WITH_MODULES
+#include <vector>
+
+import rpp.type_traits; // includes come first, the import goes last
+
+// gcc gives a variable template without `inline` one copy per translation unit
+const void* module_is_container_addr() noexcept { return &rpp::is_container<std::vector<int>>; }
+#else
+const void* module_is_container_addr() noexcept { return nullptr; }
+#endif

--- a/tests/test_sort.cpp
+++ b/tests/test_sort.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <rpp/sort.h>
+#include <rpp/collections.h> // element_range, and the two overloads only this header offers
 #include <rpp/sprint.h>
 
 // return -1 if sorted, else index where sorting breaks
@@ -168,6 +169,37 @@ TestImpl(test_sort)
         AssertFalse(is_sorted(array.data(), array.size()));
 
         rpp::insertion_sort(array, [](const std::string& a, const std::string& b) { return a < b; });
+        AssertEqual(first_unsorted_index(array.data(), array.size()), -1);
+    }
+
+    // sort.h carries the generic overloads, so <rpp/sort.h> alone sorts a vector
+    TestCase(sort_container_overload)
+    {
+        std::vector<int> array = array_random_int(32);
+        AssertFalse(is_sorted(array.data(), array.size()));
+
+        rpp::sort(array);
+        AssertEqual(first_unsorted_index(array.data(), array.size()), -1);
+
+        rpp::sort(array, [](const int& a, const int& b) { return a > b; });
+        AssertGreaterOrEqual(array[0], array[31]);
+    }
+
+    // an explicit element type names the vector overload, which collections.h keeps
+    TestCase(sort_takes_an_explicit_element_type)
+    {
+        std::vector<int> array = array_random_int(32);
+        rpp::sort<int>(array);
+        AssertEqual(first_unsorted_index(array.data(), array.size()), -1);
+    }
+
+    // a const range still sorts, because the by-value parameter copies the view, not the elements
+    TestCase(sort_const_element_range_sorts_its_elements)
+    {
+        std::vector<int> array = array_random_int(32);
+        const rpp::element_range<int> view = rpp::range(array);
+
+        rpp::sort(view, [](const int& a, const int& b) { return a < b; });
         AssertEqual(first_unsorted_index(array.data(), array.size()), -1);
     }
 

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -26,6 +26,10 @@ BASE = ('RPP_ENABLE_UNICODE=1',)
 GUARDS = (('RPP_ENABLE_UNICODE', ('RPP_ENABLE_UNICODE=0',)),
           ('!RPP_BARE_METAL', ('RPP_FREERTOS=1',)))
 
+# a macro no define reaches, because the header derives it from __has_include. The generator
+# reads the region the header guards with it instead of parsing a second configuration
+TEXT_GUARDS = ('RPP_HAS_COROUTINES',)
+
 # a using-declaration cannot name these, and an importer never needs them
 # this set omits UNEXPOSED_DECL, because libclang reports a variable template under that
 # kind and a using-declaration names one. The filters below drop the unnamed and private
@@ -120,9 +124,29 @@ def internal_names(header: str, allow: frozenset = None) -> list:
     return out
 
 
-def _condition(ns: str, name: str, reduced: dict) -> str:
+def _guarded_text(header: str) -> dict:
+    """Macro to the header text its `#if` blocks enclose, for every macro in TEXT_GUARDS."""
+    lines = _read(header).split('\n')
+    out = {}
+    for macro in TEXT_GUARDS:
+        body, depth, start = [], 0, None
+        for i, line in enumerate(lines):
+            s = line.strip()
+            if start is None:
+                if re.match(rf'#\s*if\s+{macro}\s*$', s): start, depth = i, 1
+                continue
+            if s.startswith('#if'): depth += 1
+            elif s.startswith('#endif'):
+                depth -= 1
+                if depth == 0: body += lines[start + 1:i]; start = None
+        if body: out[macro] = '\n'.join(body)
+    return out
+
+
+def _condition(ns: str, name: str, reduced: dict, guarded: dict) -> str:
     """The `#if` this name needs, or '' when every configuration declares it."""
     needs = [g for g, names in reduced.items() if name not in names.get(ns, [])]
+    needs += [m for m, body in guarded.items() if re.search(rf'\b{re.escape(name)}\b', body)]
     return ' && '.join(needs)
 
 
@@ -130,6 +154,7 @@ def export_block(header: str) -> str:
     """The generated block for one header, markers included."""
     base = _exported(header, BASE)
     reduced = {g: _exported(header, BASE + off) for g, off in GUARDS}
+    guarded = _guarded_text(header)
     lines = [BEGIN]
 
     # one export import per rpp include. config.h maps to rpp.config, and a header never imports itself
@@ -145,7 +170,7 @@ def export_block(header: str) -> str:
 
     for ns in sorted(base):
         groups = {}  # condition to the names it guards. '' sorts first, so the guards follow it
-        for name in base[ns]: groups.setdefault(_condition(ns, name, reduced), []).append(name)
+        for name in base[ns]: groups.setdefault(_condition(ns, name, reduced, guarded), []).append(name)
         if not groups: continue
         if not ns:  # a C API keeps global scope, so a call site needs no change
             lines += [''] + [f'export using ::{n};' for n in groups.get('', [])]
@@ -213,6 +238,9 @@ namespace rpp {
     struct Public {};
     template<int N> struct Sized { char c[N]; };
     template<int N> Sized(const char (&)[N]) -> Sized<N>;   // a deduction guide has no name
+#if RPP_HAS_COROUTINES
+    struct Awaited {};                             // a text guard reaches this one
+#endif
 }
 '''
 
@@ -240,6 +268,11 @@ def selftest() -> list:
         for name in ('TAU', 'Public'):
             if name not in shown: bad.append(f'{name} has external linkage and left the export list')
         if any(n.startswith('<') for n in shown): bad.append('a deduction guide reached the export list')
+        guarded = _guarded_text(path)
+        if _condition('rpp', 'Awaited', {}, guarded) != 'RPP_HAS_COROUTINES':
+            bad.append('a name inside a text-guarded block took no #if')
+        if _condition('rpp', 'Public', {}, guarded):
+            bad.append('a name outside every text-guarded block took an #if')
     return bad
 
 

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -20,9 +20,11 @@ import rpp_decls as rd
 BEGIN = '// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block'
 END = '// GENERATED EXPORTS END'
 
-# the surface changes with this macro, so the generator reads both and guards the difference
-CONFIGS = (('RPP_ENABLE_UNICODE=1',), ('RPP_ENABLE_UNICODE=0',))
-GUARD = 'RPP_ENABLE_UNICODE'
+# BASE declares the widest surface. Each guard names the condition and the defines which
+# turn it off, so the generator reads every configuration and guards what only BASE declares
+BASE = ('RPP_ENABLE_UNICODE=1',)
+GUARDS = (('RPP_ENABLE_UNICODE', ('RPP_ENABLE_UNICODE=0',)),
+          ('!RPP_BARE_METAL', ('RPP_FREERTOS=1',)))
 
 # a using-declaration cannot name these, and an importer never needs them
 # this set omits UNEXPOSED_DECL, because libclang reports a variable template under that
@@ -112,15 +114,22 @@ def internal_names(header: str, allow: frozenset = None) -> list:
     """
     allow = INTERNAL_OK if allow is None else allow
     out = []
-    for ns, kind, name, internal in rd.declarations(header, CONFIGS[0]):
+    for ns, kind, name, internal in rd.declarations(header, BASE):
         if _skip(ns, kind, name): continue
         if internal and name not in allow and name not in out: out.append(name)
     return out
 
 
+def _condition(ns: str, name: str, reduced: dict) -> str:
+    """The `#if` this name needs, or '' when every configuration declares it."""
+    needs = [g for g, names in reduced.items() if name not in names.get(ns, [])]
+    return ' && '.join(needs)
+
+
 def export_block(header: str) -> str:
     """The generated block for one header, markers included."""
-    on, off = (_exported(header, d) for d in CONFIGS)
+    base = _exported(header, BASE)
+    reduced = {g: _exported(header, BASE + off) for g, off in GUARDS}
     lines = [BEGIN]
 
     # one export import per rpp include. config.h maps to rpp.config, and a header never imports itself
@@ -134,20 +143,19 @@ def export_block(header: str) -> str:
     imports.discard(module_name(header))
     lines += [f'export import {imp};' for imp in sorted(imports)]
 
-    for ns in sorted(set(on) | set(off)):
-        both = [n for n in on.get(ns, []) if n in off.get(ns, [])]
-        only = [n for n in on.get(ns, []) if n not in off.get(ns, [])]
-        if not both and not only: continue
+    for ns in sorted(base):
+        groups = {}  # condition to the names it guards. '' sorts first, so the guards follow it
+        for name in base[ns]: groups.setdefault(_condition(ns, name, reduced), []).append(name)
+        if not groups: continue
         if not ns:  # a C API keeps global scope, so a call site needs no change
-            lines += [''] + [f'export using ::{n};' for n in both]
+            lines += [''] + [f'export using ::{n};' for n in groups.get('', [])]
             continue
         # a literal operator lives in an inline namespace, so `using namespace` reaches it
         lines += ['', f'export namespace {ns.replace("::literals", "::inline literals")} {{']
-        lines += [f'    using {ns}::{n};' for n in both]
-        if only:
-            lines.append(f'#if {GUARD}')
-            lines += [f'    using {ns}::{n};' for n in only]
-            lines.append('#endif')
+        for cond, names in sorted(groups.items()):
+            if cond: lines.append(f'#if {cond}')
+            lines += [f'    using {ns}::{n};' for n in names]
+            if cond: lines.append('#endif')
         lines.append('}')
 
     lines.append(END)
@@ -222,7 +230,7 @@ def selftest() -> list:
         path = os.path.join(d, 'probe.h')
         open(path, 'w').write(_SELFTEST_HEADER)
         hidden = internal_names(path, frozenset())
-        shown = _exported(path, CONFIGS[0]).get('rpp', [])
+        shown = _exported(path, BASE).get('rpp', [])
         for name in ('PI', 'radf', 'obfuscate'):
             if name not in hidden: bad.append(f'{name} hides from the module and the gate stayed quiet')
         if 'obfuscate' in internal_names(path, frozenset({'obfuscate'})):

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -25,9 +25,11 @@ CONFIGS = (('RPP_ENABLE_UNICODE=1',), ('RPP_ENABLE_UNICODE=0',))
 GUARD = 'RPP_ENABLE_UNICODE'
 
 # a using-declaration cannot name these, and an importer never needs them
+# this set omits UNEXPOSED_DECL, because libclang reports a variable template under that
+# kind and a using-declaration names one. The filters below drop the unnamed and private
 SKIP_KINDS = frozenset({'MACRO_DEFINITION', 'MACRO_INSTANTIATION', 'INCLUSION_DIRECTIVE',
                         'STATIC_ASSERT', 'NAMESPACE_ALIAS', 'USING_DIRECTIVE',
-                        'USING_DECLARATION', 'FRIEND_DECL', 'UNEXPOSED_DECL'})
+                        'USING_DECLARATION', 'FRIEND_DECL'})
 
 # the logging macros need these two, so they export despite the __ prefix
 _MACRO_HELPERS = frozenset({'__wrap', '__clean_type'})

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -100,13 +100,12 @@ def macro_collision(name: str) -> bool:
 
 
 def _exported(header: str, defines: tuple) -> dict:
-    """Namespace to ordered names, for one macro configuration."""
+    """Namespace to name to declaration line, for one macro configuration, in source order."""
     out = {}
-    for ns, kind, name, internal in rd.declarations(header, defines):
+    for ns, kind, name, internal, line in rd.declarations(header, defines):
         if _skip(ns, kind, name): continue
         if internal: continue  # clang rejects a using-declaration which exports one
-        names = out.setdefault(ns, [])
-        if name not in names: names.append(name)
+        out.setdefault(ns, {}).setdefault(name, line)
     return out
 
 
@@ -118,19 +117,23 @@ def internal_names(header: str, allow: frozenset = None) -> list:
     """
     allow = INTERNAL_OK if allow is None else allow
     out = []
-    for ns, kind, name, internal in rd.declarations(header, BASE):
+    for ns, kind, name, internal, line in rd.declarations(header, BASE):
         if _skip(ns, kind, name): continue
         if internal and name not in allow and name not in out: out.append(name)
     return out
 
 
-def _guarded_text(header: str) -> dict:
-    """Macro to the header text its `#if` blocks enclose, for every macro in TEXT_GUARDS."""
+def _guarded_spans(header: str) -> dict:
+    """Macro to the line spans its `#if` blocks cover, for every macro in TEXT_GUARDS.
+
+    A span holds line numbers, not text. A block which only mentions an unconditional class
+    would otherwise guard that whole class, and hide its API wherever the macro is 0.
+    """
     lines = _read(header).split('\n')
     out = {}
     for macro in TEXT_GUARDS:
-        body, depth, start = [], 0, None
-        for i, line in enumerate(lines):
+        spans, depth, start = [], 0, None
+        for i, line in enumerate(lines, 1):
             s = line.strip()
             if start is None:
                 if re.match(rf'#\s*if\s+{macro}\s*$', s): start, depth = i, 1
@@ -138,15 +141,25 @@ def _guarded_text(header: str) -> dict:
             if s.startswith('#if'): depth += 1
             elif s.startswith('#endif'):
                 depth -= 1
-                if depth == 0: body += lines[start + 1:i]; start = None
-        if body: out[macro] = '\n'.join(body)
+                if depth == 0: spans.append((start, i)); start = None
+        if spans: out[macro] = spans
     return out
 
 
-def _condition(ns: str, name: str, reduced: dict, guarded: dict) -> str:
+def _open_namespace(header: str, ns: str) -> str:
+    """`ns` with each component the header declares inline marked inline.
+
+    A literal operator lives in an inline namespace, so `using namespace rpp` reaches it. The
+    module has to reopen that namespace inline too, or the importer loses the lookup.
+    """
+    inlines = set(re.findall(r'^\s*inline\s+namespace\s+(\w+)', _read(header), re.M))
+    return '::'.join(f'inline {p}' if p in inlines else p for p in ns.split('::'))
+
+
+def _condition(ns: str, name: str, line: int, reduced: dict, spans: dict) -> str:
     """The `#if` this name needs, or '' when every configuration declares it."""
-    needs = [g for g, names in reduced.items() if name not in names.get(ns, [])]
-    needs += [m for m, body in guarded.items() if re.search(rf'\b{re.escape(name)}\b', body)]
+    needs = [g for g, names in reduced.items() if name not in names.get(ns, {})]
+    needs += [m for m, sp in spans.items() if any(a < line < b for a, b in sp)]
     return ' && '.join(needs)
 
 
@@ -154,7 +167,7 @@ def export_block(header: str) -> str:
     """The generated block for one header, markers included."""
     base = _exported(header, BASE)
     reduced = {g: _exported(header, BASE + off) for g, off in GUARDS}
-    guarded = _guarded_text(header)
+    spans = _guarded_spans(header)
     lines = [BEGIN]
 
     # one export import per rpp include. config.h maps to rpp.config, and a header never imports itself
@@ -170,13 +183,13 @@ def export_block(header: str) -> str:
 
     for ns in sorted(base):
         groups = {}  # condition to the names it guards. '' sorts first, so the guards follow it
-        for name in base[ns]: groups.setdefault(_condition(ns, name, reduced, guarded), []).append(name)
+        for name, line in base[ns].items():
+            groups.setdefault(_condition(ns, name, line, reduced, spans), []).append(name)
         if not groups: continue
         if not ns:  # a C API keeps global scope, so a call site needs no change
             lines += [''] + [f'export using ::{n};' for n in groups.get('', [])]
             continue
-        # a literal operator lives in an inline namespace, so `using namespace` reaches it
-        lines += ['', f'export namespace {ns.replace("::literals", "::inline literals")} {{']
+        lines += ['', f'export namespace {_open_namespace(header, ns)} {{']
         for cond, names in sorted(groups.items()):
             if cond: lines.append(f'#if {cond}')
             lines += [f'    using {ns}::{n};' for n in names]
@@ -230,6 +243,7 @@ def with_modules() -> list:
 
 
 _SELFTEST_HEADER = '''#pragma once
+#define RPP_HAS_COROUTINES 1                       // the real header derives this from __has_include
 namespace rpp {
     constexpr double PI = 3.14159;                 // const at namespace scope, so internal
     static constexpr float radf(float d);          // static, so internal
@@ -239,8 +253,14 @@ namespace rpp {
     template<int N> struct Sized { char c[N]; };
     template<int N> Sized(const char (&)[N]) -> Sized<N>;   // a deduction guide has no name
 #if RPP_HAS_COROUTINES
-    struct Awaited {};                             // a text guard reaches this one
+    struct Awaited {};                             // a guard span covers this declaration
 #endif
+    class Unconditional {                          // the span below names it, and must not guard it
+    public:
+#if RPP_HAS_COROUTINES
+        void await(Unconditional& u);
+#endif
+    };
 }
 '''
 
@@ -258,7 +278,8 @@ def selftest() -> list:
         path = os.path.join(d, 'probe.h')
         open(path, 'w').write(_SELFTEST_HEADER)
         hidden = internal_names(path, frozenset())
-        shown = _exported(path, BASE).get('rpp', [])
+        rpp_ns = _exported(path, BASE).get('rpp', {})
+        shown = list(rpp_ns)
         for name in ('PI', 'radf', 'obfuscate'):
             if name not in hidden: bad.append(f'{name} hides from the module and the gate stayed quiet')
         if 'obfuscate' in internal_names(path, frozenset({'obfuscate'})):
@@ -268,11 +289,14 @@ def selftest() -> list:
         for name in ('TAU', 'Public'):
             if name not in shown: bad.append(f'{name} has external linkage and left the export list')
         if any(n.startswith('<') for n in shown): bad.append('a deduction guide reached the export list')
-        guarded = _guarded_text(path)
-        if _condition('rpp', 'Awaited', {}, guarded) != 'RPP_HAS_COROUTINES':
-            bad.append('a name inside a text-guarded block took no #if')
-        if _condition('rpp', 'Public', {}, guarded):
-            bad.append('a name outside every text-guarded block took an #if')
+        spans = _guarded_spans(path)
+        if _condition('rpp', 'Awaited', rpp_ns['Awaited'], {}, spans) != 'RPP_HAS_COROUTINES':
+            bad.append('a declaration inside a guard span took no #if')
+        if _condition('rpp', 'Public', rpp_ns['Public'], {}, spans):
+            bad.append('a declaration outside every guard span took an #if')
+        # the guarded member names its own class, and a text search would guard the class too
+        if _condition('rpp', 'Unconditional', rpp_ns['Unconditional'], {}, spans):
+            bad.append('a class a guarded member names took an #if')
     return bad
 
 

--- a/tools/rpp_decls.py
+++ b/tools/rpp_decls.py
@@ -106,6 +106,10 @@ def declarations(header: str, defines: tuple = ()) -> list:
                 continue
             f = k.location.file
             if not (f and os.path.abspath(f.name) == me and k.spelling): continue
+            # an out-of-line member definition sits at namespace scope but declares nothing new,
+            # so its class semantic parent tells it apart from a real namespace declaration
+            sp = k.semantic_parent
+            if sp is not None and sp.kind.name in _MEMBER_PARENTS: continue
             internal = k.linkage == cindex.LinkageKind.INTERNAL
             out.append(('::'.join(ns), k.kind.name, k.spelling, internal))
             # an unscoped enum needs one using-declaration per enumerator, the enum type does not carry them
@@ -118,6 +122,11 @@ def declarations(header: str, defines: tuple = ()) -> list:
     return out
 
 
+# the module imports cindex lazily, so this names the kinds instead of holding the enum values
+_MEMBER_PARENTS = frozenset({'CLASS_DECL', 'STRUCT_DECL', 'UNION_DECL', 'CLASS_TEMPLATE',
+                             'CLASS_TEMPLATE_PARTIAL_SPECIALIZATION'})
+
+
 _SELFTEST_HEADER = '''#pragma once
 namespace rpp {
     enum Sev { SevInfo, SevWarn };                 // unscoped, its enumerators sit at rpp scope
@@ -126,6 +135,9 @@ namespace rpp {
     template<class T> struct __hidden {};          // a private double-underscore name
     static constexpr int internal_fn(int i) { return i; } // internal linkage, never exportable
     struct Public {};
+    template<class T> constexpr bool var_tmpl = true;    // libclang calls this UNEXPOSED_DECL
+    template<class T> struct Holder { void method(); };  // its out-of-line body sits at namespace scope
+    template<class T> void Holder<T>::method() {}        // declares nothing new, so it never exports
 }
 extern "C" { void c_api(); }                       // one linkage spec deep, like RPPCAPI
 '''
@@ -142,7 +154,8 @@ def selftest() -> list:
         got = {(ns, name) for ns, kind, name, internal in decls}
         want = {('rpp', 'Sev'), ('rpp', 'SevInfo'), ('rpp', 'SevWarn'),  # unscoped enum + members
                 ('rpp', 'Scoped'), ('rpp', '__wrap'), ('rpp', '__hidden'),
-                ('rpp', 'Public'), ('rpp', 'internal_fn'), ('', 'c_api')}  # extern "C" reaches c_api
+                ('rpp', 'Public'), ('rpp', 'internal_fn'), ('', 'c_api'),  # extern "C" reaches c_api
+                ('rpp', 'var_tmpl')}  # a variable template is public API, so it must export
         missing = want - got
         if missing: bad.append(f'declarations dropped {sorted(missing)}')
         # a scoped enum keeps its members out of the namespace
@@ -151,6 +164,8 @@ def selftest() -> list:
         flags = {name: internal for ns, kind, name, internal in decls}
         if not flags.get('internal_fn'): bad.append('a static function is not marked internal')
         if flags.get('Public'): bad.append('an external-linkage struct is marked internal')
+        # an out-of-line member body would export a name no namespace holds, and the module fails to build
+        if ('rpp', 'method') in got: bad.append('an out-of-line member definition reached the namespace')
     return bad
 
 

--- a/tools/rpp_decls.py
+++ b/tools/rpp_decls.py
@@ -86,10 +86,11 @@ def _cursors_in(tu, path: str):
 
 
 def declarations(header: str, defines: tuple = ()) -> list:
-    """The declarations this header makes, as `(namespace, kind, name, internal)`, in source order.
+    """The declarations this header makes, as `(namespace, kind, name, internal, line)`, in source order.
 
     One declaration carries every overload of a name, so the caller deduplicates. `internal`
-    marks internal linkage, which clang refuses to export. The caller decides what to do.
+    marks internal linkage, which clang refuses to export. `line` locates the declaration, so a
+    caller can tell a name declared inside a `#if` from one the block only mentions.
     """
     cindex = _cindex()
     me = os.path.abspath(_resolve(header))
@@ -111,12 +112,12 @@ def declarations(header: str, defines: tuple = ()) -> list:
             sp = k.semantic_parent
             if sp is not None and sp.kind.name in _MEMBER_PARENTS: continue
             internal = k.linkage == cindex.LinkageKind.INTERNAL
-            out.append(('::'.join(ns), k.kind.name, k.spelling, internal))
+            out.append(('::'.join(ns), k.kind.name, k.spelling, internal, k.location.line))
             # an unscoped enum needs one using-declaration per enumerator, the enum type does not carry them
             if k.kind == cindex.CursorKind.ENUM_DECL and not k.is_scoped_enum():
                 for e in k.get_children():
                     if e.kind == cindex.CursorKind.ENUM_CONSTANT_DECL and e.spelling:
-                        out.append(('::'.join(ns), e.kind.name, e.spelling, False))
+                        out.append(('::'.join(ns), e.kind.name, e.spelling, False, e.location.line))
 
     walk(parse(header, defines).cursor, [])
     return out
@@ -151,7 +152,7 @@ def selftest() -> list:
         path = os.path.join(d, 'probe.h')
         open(path, 'w').write(_SELFTEST_HEADER)
         decls = declarations(path)
-        got = {(ns, name) for ns, kind, name, internal in decls}
+        got = {(ns, name) for ns, kind, name, internal, line in decls}
         want = {('rpp', 'Sev'), ('rpp', 'SevInfo'), ('rpp', 'SevWarn'),  # unscoped enum + members
                 ('rpp', 'Scoped'), ('rpp', '__wrap'), ('rpp', '__hidden'),
                 ('rpp', 'Public'), ('rpp', 'internal_fn'), ('', 'c_api'),  # extern "C" reaches c_api
@@ -161,7 +162,7 @@ def selftest() -> list:
         # a scoped enum keeps its members out of the namespace
         if ('rpp', 'A') in got: bad.append('a scoped enum leaked its enumerator A')
         # clang refuses to export an internal-linkage name, so the caller needs to see the flag
-        flags = {name: internal for ns, kind, name, internal in decls}
+        flags = {name: internal for ns, kind, name, internal, line in decls}
         if not flags.get('internal_fn'): bad.append('a static function is not marked internal')
         if flags.get('Public'): bad.append('an external-linkage struct is marked internal')
         # an out-of-line member body would export a name no namespace holds, and the module fails to build


### PR DESCRIPTION
Changeset 5 of `docs/MODULES_MIGRATION.md`. The module count goes from 6 to 24: the whole
L1 layer, and six of the eight in L2.

| Layer | Modules |
|---|---|
| L1 | bitutils, delegate, endian, future_types, math, predicates, proc_utils, sort, source_loc, timepoint, traits, type_traits |
| L2 | atomic_timepoint, collections, stack_trace, threads, timer, vec |

Every module carries a case in `tests/test_modules.cpp` that includes no header of its own,
so the module alone has to supply the names.

## Six headers declared API the compiler could not export

Writing the `.cppm` files was the easy half. The layer found real defects:

| Header | Defect | Exported |
|---|---|---|
| `math.h` | every function `static` at namespace scope, constants without `inline` | 0 of 14 → 14 |
| `traits.h` | the `function_traits` family inside an **anonymous namespace** | 0 of 8 → 8 |
| `timepoint.h` | nine namespace-scope constants without `inline` | 0 → 25 |
| `type_traits.h` | nine variable templates without `inline`, so each importer got its own copy | see below |
| `stack_trace.h` | `CALLSTACK_MAX_DEPTH` marked `static` beside `inline` | 11 → 12 |

`traits.h` is worth a second look beyond modules. An anonymous namespace inside
`namespace rpp` made `rpp::function_traits` a **different type in every translation unit**
that included it. That predates this work and has nothing to do with modules.

`type_traits.h` is the same class of defect one level down. A namespace-scope `constexpr`
variable template without `inline` gets one copy per translation unit on gcc, so the module
importer and the header includer saw **different addresses for the same trait**. A probe on
gcc 14.2 reported `plain same=0` against `inline same=1`, and `nm` marks the symbol local.
`tests/test_modules_identity.cpp` takes the address through the module alone, and
`test_modules.cpp` compares it against the header address.

## The generator learned three configuration rules

The generator emitted an export list for whatever configuration it happened to parse in, so
any declaration a header hides under a different configuration became an unguarded export.
It now handles three cases, each pinned by a selftest:

1. **A macro a define can toggle** — `RPP_ENABLE_UNICODE` and `!RPP_BARE_METAL`. The
   generator parses each configuration and guards the difference. `threads.h` drops from 7
   declarations to 1 under `RPP_FREERTOS=1`, and `type_traits.h` from 22 to 20.
2. **A macro no define reaches** — `RPP_HAS_COROUTINES`, which the header derives from
   `__has_include`. The generator reads the region the header brackets with it.
3. **An inline namespace** — read from the header, rather than guessed from a name ending in
   `::literals`. That spelling missed `rpp::duration_literals`, so a module consumer lost
   `using namespace rpp; 1_s`.

Rule 2 matches by declaration location, not by name text. A text search also matched a name
a guarded block only mentions, which would have hidden the whole `rpp::semaphore` and
`rpp::concurrent_queue` classes on a target without `<coroutine>`. Neither header carries a
module yet, so nothing shipped broken, and the L3 layer would have hit it.

## Two more generator defects, each pinned by a selftest

1. **An out-of-line member definition reached the export list.** `delegate.h` defines
   `delegate<...>::operator()` and `::invoke` at namespace scope, so the traversal emitted
   `using rpp::operator();` and the module failed to build. A cursor whose semantic parent
   is a class no longer counts.
2. **`SKIP_KINDS` dropped `UNEXPOSED_DECL`**, which is the kind libclang reports for a
   variable template, so every variable template was missing from every module. A
   measurement over all headers put the cost at nine names, all in `type_traits.h`, all
   external linkage.

## sprint and task do not ship

gcc-14 writes a `.gcm` for each and no importer reads it back:

```
rpp.sprint: error: failed to read compiled module cluster 1510: Bad file data
fatal error: failed to load pendings for 'std::_Mutex_base'
```

The message names a libstdc++ internal, so this is a compiler defect and not a wrong export
list. Each module fails alone, and a consumer that includes `<mutex>` before the import
fails the same way. `BUGS.md` **B8** carries the reproducer, which writes the interface
skeleton first, because no `rpp-sprint.cppm` ever landed in a commit.

Both `.cppm` files wait, because a module no importer can read would leave the build green
while the module stayed unusable. `sprint` blocks the most, since `string_buffer`, `format`
and every `to_string` overload sit in that header, so the plan now names it the step before
the L3 layer. Only clang-21 and a newer gcc can answer whether B8 is gcc-only, and this
machine carries clang-18, which cannot build modules at all.

## Verified

- modules build: **549/549** pass, up from 533
- header build: **528/528** pass, which is what proves the linkage changes are safe off the
  modules path
- all three generator gates report no finding, selftests included
- four module-only consumers exit 0
- clang-tidy reports nothing over 54 translation units
- CI: 28 of 28 jobs pass on `26c382e`, first attempt

Two TSAN jobs flaked earlier in the branch, on a different job each run, and a re-run cleared
each one. Both are catalogued: `BUGS.md` **B6**, the exception refcount inside an
uninstrumented libstdc++ or libc++abi, and **B2**, a 5 ms timing budget on a runner which
reports 2 usable cores. Neither is this changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJQak2qMQ4cXHtqEcpwimN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJQak2qMQ4cXHtqEcpwimN)_