### PR TITLE
modules: land rpp.sprint and rpp.task, fix the TSAN hook, and move the traits to concepts

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -37,6 +37,23 @@ were tried, including a block-scope object feeding a printf sink.
 A fix needs a translation unit which folds on demand, so a separate tiny target under
 `tests/` is the likely answer.
 
+### B11. The documented clang-tidy gate analyzes nothing on a warm build tree
+`CXX20=1 mama gcc build clang-tidy test="nogdb -vv"` exits 0 and reports no finding, while the
+CI job of the same name fails. AGENTS.md names that command as the gate, so a session which
+trusts it pushes a red build. Two rounds on PR #73 went red this way.
+
+`packages/ReCpp/linux/CMakeCache.txt` carries no `CMAKE_CXX_CLANG_TIDY` after that command.
+mama reuses the build directory a plain build configured, so the analysis never turns on.
+Adding `configure` sets the variable, and then a gcc-14 build stops instead, because
+clang-tidy is clang and cannot parse `-fmodules-ts`, `-fmodule-mapper=` or `-fdeps-format=`.
+The CI gcc-13 jobs never hit that, because gcc-13 builds no modules.
+
+Until this is fixed, check one finding against clang-tidy directly:
+```bash
+clang-tidy-18 --checks='-*,performance-enum-size' tests/test_sprint.cpp -- -std=c++23 -Isrc
+```
+A fix makes the documented command reconfigure, and turns modules off for the analysis.
+
 ### B10. A pool worker reads its semaphore after the pool destroyed it
 TSAN reports `heap-use-after-free` at shutdown, 1 run in 80. The main thread runs
 `~unique_ptr<pool_worker>` out of the worker vector, while `pool_worker::run()` is still

--- a/BUGS.md
+++ b/BUGS.md
@@ -61,8 +61,16 @@ inside `rpp::semaphore::spin_lock()` at `semaphore.h:102`. A second report reads
 `pool_task_state` shared pointer the same way.
 
 This is a lifecycle order defect, not a refcount TSAN cannot see, so C25 does not cover it
-and no suppression should. Reproduce it with the C25 loop below, and read the
-`heap-use-after-free` reports instead of the races.
+and no suppression should. Two pinned cores reproduce it, and the `race:` patterns never hide
+a `heap-use-after-free`:
+```bash
+CXX20=1 mama gcc tsan build
+for i in $(seq 1 40); do for j in 1 2; do
+  taskset -c 0,1 env TSAN_OPTIONS="halt_on_error=0" \
+    packages/ReCpp/linux-tsan/RppTests test_future > /tmp/b10_${i}_$j.log 2>&1 &
+done; wait; done
+grep -l 'heap-use-after-free' /tmp/b10_*.log
+```
 
 ### B8. gcc-14 writes an unreadable module for two shapes, and both have a workaround
 `tools/gen_module_exports.py` carries `NO_EXPORT` and `NO_IMPORT`, one entry each. Both

--- a/BUGS.md
+++ b/BUGS.md
@@ -37,17 +37,15 @@ were tried, including a block-scope object feeding a printf sink.
 A fix needs a translation unit which folds on demand, so a separate tiny target under
 `tests/` is the likely answer.
 
-### B6. The C15 TSAN suppression covers libc++ only, so gcc still reports the future race
-C15 closed the same false positive on clang. `tests/main.cpp` guards
-`__tsan_default_suppressions` with `#if defined(__clang__)`, and the pattern it returns
-is `race:std::__1::promise`, which is the libc++ spelling. Under gcc the entity is
-`std::__future_base::_State_baseV2`, so no pattern matches and no suppression compiles.
-The gcc TSAN jobs report it intermittently, in `~_State_baseV2`, in
-`exception_ptr::_M_release`, and in `~runtime_error` freeing the string that
-`test_future::test_except_handler_chaining` reads on another worker. All of them sit
-inside an uninstrumented `libstdc++.so`.
-Read C15 first. A fix adds the gcc branch and a libstdc++ pattern, and it needs a run
-which proves the suppression hides this race and hides no other.
+### B10. A pool worker reads its semaphore after the pool destroyed it
+TSAN reports `heap-use-after-free` at shutdown, 1 run in 80. The main thread runs
+`~unique_ptr<pool_worker>` out of the worker vector, while `pool_worker::run()` is still
+inside `rpp::semaphore::spin_lock()` at `semaphore.h:102`. A second report reads the
+`pool_task_state` shared pointer the same way.
+
+This is a lifecycle order defect, not a refcount TSAN cannot see, so C25 does not cover it
+and no suppression should. Reproduce it with the C25 loop below, and read the
+`heap-use-after-free` reports instead of the races.
 
 ### B8. gcc-14 writes a module for sprint.h and task.h that no importer can read
 Both `.cppm` files compile, and the `.gcm` lands. An importer then stops with
@@ -109,6 +107,31 @@ inside `DbgAssert`, not the `#define LogError` at line 139. Corrected by hand.
 The script's own docstring already warns that it has mistakes.
 
 ## Closed
+
+### C25. libtsan.so never read the suppression hook, because it was hidden (was B6)
+B6 blamed the libc++ spelling of the C15 pattern. The real cause is one attribute. gcc links
+`libtsan.so`, which reads `__tsan_default_suppressions` through the global dynamic symbol
+table, and `-fvisibility=hidden` kept the definition out of it. `dlsym` then answered with the
+weak hook inside `libtsan.so`, which returns null, so every pattern was dead. clang links its
+runtime statically, which is why C15 worked there.
+
+The hook and its patterns moved to `tests/test_sanitizers.cpp`, beside the test which calls
+`dlsym(RTLD_DEFAULT, ...)` and reads the string back. That test fails without the attribute.
+
+Both reports name `test_future::test_except_handler_chaining`, which shares one exception
+object between two pool workers. The refcount which orders them sits in an uninstrumented
+`libstdc++.so`, so TSAN sees no edge.
+
+Measured on 2 pinned cores: 3 reports in 120 runs before, 0 in 120 after, and the two patterns
+matched 3 times each. Ten full-suite runs matched no suppression at all and passed every case.
+```bash
+CXX20=1 mama gcc tsan build
+for i in $(seq 1 60); do for j in 1 2; do
+  taskset -c 0,1 env TSAN_OPTIONS="halt_on_error=0 print_suppressions=1" \
+    packages/ReCpp/linux-tsan/RppTests test_future > /tmp/w_${i}_$j.log 2>&1 &
+done; wait; done
+grep -l 'WARNING: ThreadSanitizer' /tmp/w_*.log | wc -l
+```
 
 ### C24. `_va_comma` dropped the argument list when the first argument started with `(`
 The one-probe fallback let `_spaces_on_empty_token` consume that leading paren, so the

--- a/BUGS.md
+++ b/BUGS.md
@@ -51,6 +51,10 @@ and no suppression should. Reproduce it with the C25 loop below, and read the
 `tools/gen_module_exports.py` carries `NO_EXPORT` and `NO_IMPORT`, one entry each. Both
 modules ship now. Delete an entry when a newer gcc reads the module back.
 
+`NO_CONFIG` is a third list, and it is not a gcc defect. `sprint.h` needs `std::to_string`,
+which bare metal drops, so the header does not compile in that configuration at all. Any
+parse failure the list does not name reaches the caller and fails the run.
+
 The importer stops with `failed to read compiled module cluster N: Bad file data`, then
 `failed to load pendings for` a libstdc++ internal. That name changes per run, and the
 cluster number does too, so neither one identifies the shape.
@@ -115,29 +119,9 @@ The script's own docstring already warns that it has mistakes.
 ## Closed
 
 ### C25. libtsan.so never read the suppression hook, because it was hidden (was B6)
-B6 blamed the libc++ spelling of the C15 pattern. The real cause is one attribute. gcc links
-`libtsan.so`, which reads `__tsan_default_suppressions` through the global dynamic symbol
-table, and `-fvisibility=hidden` kept the definition out of it. `dlsym` then answered with the
-weak hook inside `libtsan.so`, which returns null, so every pattern was dead. clang links its
-runtime statically, which is why C15 worked there.
-
-The hook and its patterns moved to `tests/test_sanitizers.cpp`, beside the test which calls
-`dlsym(RTLD_DEFAULT, ...)` and reads the string back. That test fails without the attribute.
-
-Both reports name `test_future::test_except_handler_chaining`, which shares one exception
-object between two pool workers. The refcount which orders them sits in an uninstrumented
-`libstdc++.so`, so TSAN sees no edge.
-
-Measured on 2 pinned cores: 3 reports in 120 runs before, 0 in 120 after, and the two patterns
-matched 3 times each. Ten full-suite runs matched no suppression at all and passed every case.
-```bash
-CXX20=1 mama gcc tsan build
-for i in $(seq 1 60); do for j in 1 2; do
-  taskset -c 0,1 env TSAN_OPTIONS="halt_on_error=0 print_suppressions=1" \
-    packages/ReCpp/linux-tsan/RppTests test_future > /tmp/w_${i}_$j.log 2>&1 &
-done; wait; done
-grep -l 'WARNING: ThreadSanitizer' /tmp/w_*.log | wc -l
-```
+`-fvisibility=hidden` kept `__tsan_default_suppressions` out of the dynamic symbol table gcc's
+`libtsan.so` reads, so every pattern was dead. The hook took a default-visibility attribute and
+moved to `tests/test_sanitizers.cpp`, beside a `dlsym` test which fails without it.
 
 ### C24. `_va_comma` dropped the argument list when the first argument started with `(`
 The one-probe fallback let `_spaces_on_empty_token` consume that leading paren, so the

--- a/BUGS.md
+++ b/BUGS.md
@@ -47,33 +47,39 @@ This is a lifecycle order defect, not a refcount TSAN cannot see, so C25 does no
 and no suppression should. Reproduce it with the C25 loop below, and read the
 `heap-use-after-free` reports instead of the races.
 
-### B8. gcc-14 writes a module for sprint.h and task.h that no importer can read
-Both `.cppm` files compile, and the `.gcm` lands. An importer then stops with
-`failed to read compiled module cluster N: Bad file data`, followed by
-`fatal error: failed to load pendings for 'std::_Mutex_base'`. The message names a
-libstdc++ internal, so this is a compiler defect and not an export list mistake.
-Neither module ships until a toolchain reads them back.
+### B8. gcc-14 writes an unreadable module for two shapes, and both have a workaround
+`tools/gen_module_exports.py` carries `NO_EXPORT` and `NO_IMPORT`, one entry each. Both
+modules ship now. Delete an entry when a newer gcc reads the module back.
 
-Each one fails alone, so no pair of modules causes it. A consumer that includes
-`<mutex>` before the import fails the same way. The other eighteen modules import.
+The importer stops with `failed to read compiled module cluster N: Bad file data`, then
+`failed to load pendings for` a libstdc++ internal. That name changes per run, and the
+cluster number does too, so neither one identifies the shape.
 
-Reproduce it. No `rpp-sprint.cppm` ever landed, so write the skeleton first. The generator
-fills the block, and it refuses a file which carries no markers.
+Shape 1, in `rpp.sprint`. An export naming a function in the `std::__cxx11` inline namespace
+makes the module unreadable. `std::to_string` and `std::stoi` both do it, and `std::swap`
+does not. The form does not matter. An `is_detected_v` alias, a plain alias template and a
+C++20 concept all fail the same way. So does a concept which calls an unexported helper that
+names it. `NO_EXPORT` drops `has_std_to_string` from `rpp.type_traits`, which is what
+`rpp.sprint` imports. A header includer still gets the trait.
+
+Shape 2, in `rpp.task`. A module which includes `future_types.h` in its global module
+fragment and also imports `rpp.future_types` writes an unreadable `.gcm`. Either half alone
+is fine. The importer only fails when it also includes `<rpp/tests.h>`. `NO_IMPORT` drops that
+one re-export, so an importer of `rpp.task` which needs `rpp::coro_handle` imports
+`rpp.future_types` itself.
+
+Reproduce either shape in seconds, outside cmake. Build every `.cppm` in the
+`RPP_MODULES_SRC` order into one `gcm.cache`, then compile a consumer:
 ```bash
-cat > src/rpp/rpp-sprint.cppm <<'EOF'
-module;
-#include "sprint.h"
-export module rpp.sprint;
-// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-// GENERATED EXPORTS END
-EOF
-python3 tools/gen_module_exports.py sprint.h
-# add src/rpp/rpp-sprint.cppm to RPP_MODULES_SRC in CMakeLists.txt
-# add `import rpp.sprint;` to tests/module_consumer/masked_module_only.cpp
-cd tests/module_consumer
-CXX20=1 python3 run_test.py --compiler gcc --expect modules --jobs 4
+cd $(mktemp -d)
+for f in $(sed -n '/set(RPP_MODULES_SRC/,/^    )/p' ~/ReCpp/CMakeLists.txt | grep -o 'src/rpp/rpp-[a-z_]*\.cppm'); do
+  g++ -std=c++20 -fmodules-ts -I ~/ReCpp/src -c -x c++ ~/ReCpp/$f -o $(basename $f .cppm).o
+done
+printf '#include <rpp/tests.h>\nimport rpp.task;\nint main(){return 0;}\n' > u.cpp
+g++ -std=c++20 -fmodules-ts -I ~/ReCpp/src -c u.cpp -o u.o    # 0 errors with NO_IMPORT
 ```
-Retry it on clang-21 and on a gcc newer than 14.2. Only gcc 14.2 ran this check.
+Put the offending line back into the generated block by hand to watch it fail. Only gcc 14.2
+ran this check, so retry on clang-21 and on a newer gcc.
 
 ### B9. `--check-undocumented` reads 29 of the 48 headers and reports the rest as clean
 `extract_public_decls` returns nothing for 19 headers, so the gate never asks whether

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,8 @@ if(RPP_BUILD_MODULES)
         src/rpp/rpp-threads.cppm
         src/rpp/rpp-timer.cppm
         src/rpp/rpp-vec.cppm
+        src/rpp/rpp-sprint.cppm
+        src/rpp/rpp-task.cppm
     )
 
     # Add module interface to the library target

--- a/README.md
+++ b/README.md
@@ -706,25 +706,27 @@ Fast string building and type-safe formatting. `string_buffer` is an always-null
 
 | Item | Description |
 |------|-------------|
-| [`string_buffer`](src/rpp/sprint.h#L77) | Fast, always-null-terminated string builder |
+| [`string_buffer`](src/rpp/sprint.h#L73) | Fast, always-null-terminated string builder |
 | [`format_opt`](src/rpp/sprint.h#L66) | Format options enum: `none`, `lowercase`, `uppercase` |
+| [`has_ostream_op<T>`](src/rpp/sprint.h#L76) | True if `std::ostream << T` is valid |
+| [`has_member_sbuf_op<T>`](src/rpp/sprint.h#L79) | True if `T::operator<<(string_buffer&)` exists |
 
 ### string_buffer Methods
 
 | Method | Description |
 |--------|-------------|
-| [`write(const T& v)`](src/rpp/sprint.h#L125) | Write a value (auto-converts most types) |
-| [`write_real(double value, int maxDecimals)`](src/rpp/sprint.h#L150) | Write a float or double with a chosen number of decimals, instead of the default 6 |
-| [`writeln(const Args&... args)`](src/rpp/sprint.h#L360) | Write values followed by newline |
-| [`writef(const char* format, ...)`](src/rpp/sprint.h#L123) | Printf-style formatted write |
-| [`write_hex(const void* data, int numBytes)`](src/rpp/sprint.h#L310) | Write data as hex string |
-| [`write_cont(const Container& c)`](src/rpp/sprint.h#L267) | Write container contents |
-| [`prettyprint(const T& value)`](src/rpp/sprint.h#L368) | Pretty-print a value |
-| [`clear()`](src/rpp/sprint.h#L114) | Clear the buffer |
-| [`reserve(int capacity)`](src/rpp/sprint.h#L115) | Reserve capacity |
-| [`resize(int size)`](src/rpp/sprint.h#L116) | Resize buffer |
-| [`append(const char* data, int len)`](src/rpp/sprint.h#L119) | Append raw data |
-| [`emplace_buffer(int n)`](src/rpp/sprint.h#L122) | Get writable buffer of N bytes |
+| [`write(const T& v)`](src/rpp/sprint.h#L133) | Write a value (auto-converts most types) |
+| [`write_real(double value, int maxDecimals)`](src/rpp/sprint.h#L158) | Write a float or double with a chosen number of decimals, instead of the default 6 |
+| [`writeln(const Args&... args)`](src/rpp/sprint.h#L359) | Write values followed by newline |
+| [`writef(const char* format, ...)`](src/rpp/sprint.h#L131) | Printf-style formatted write |
+| [`write_hex(const void* data, int numBytes)`](src/rpp/sprint.h#L309) | Write data as hex string |
+| [`write_cont(const Container& c)`](src/rpp/sprint.h#L266) | Write container contents |
+| [`prettyprint(const T& value)`](src/rpp/sprint.h#L367) | Pretty-print a value |
+| [`clear()`](src/rpp/sprint.h#L122) | Clear the buffer |
+| [`reserve(int capacity)`](src/rpp/sprint.h#L123) | Reserve capacity |
+| [`resize(int size)`](src/rpp/sprint.h#L124) | Resize buffer |
+| [`append(const char* data, int len)`](src/rpp/sprint.h#L127) | Append raw data |
+| [`emplace_buffer(int n)`](src/rpp/sprint.h#L130) | Get writable buffer of N bytes |
 
 ### Free Functions
 
@@ -735,9 +737,9 @@ Fast string building and type-safe formatting. `string_buffer` is an always-null
 | [`to_string(float)`](src/rpp/sprint.h#L51) | Locale-agnostic float to string |
 | [`to_string(double)`](src/rpp/sprint.h#L52) | Locale-agnostic double to string |
 | [`to_string(bool)`](src/rpp/sprint.h#L55) | Bool to `"true"` or `"false"` |
-| [`print(args...)`](src/rpp/sprint.h#L482) | Print to stdout |
-| [`println(args...)`](src/rpp/sprint.h#L502) | Print to stdout with newline |
-| [`to_hex_string(s, opt)`](src/rpp/sprint.h#L428) | Converts string bytes to hexadecimal representation |
+| [`print(args...)`](src/rpp/sprint.h#L481) | Print to stdout |
+| [`println(args...)`](src/rpp/sprint.h#L501) | Print to stdout with newline |
+| [`to_hex_string(s, opt)`](src/rpp/sprint.h#L427) | Converts string bytes to hexadecimal representation |
 
 ### Example: Basic String Building
 
@@ -1791,7 +1793,7 @@ Cross-platform mutex, spin locks, and synchronized value wrappers.
 | [`mutex`](src/rpp/mutex.h#L14) | Platform-specific mutex (custom on Windows/FreeRTOS, `std::mutex` on Linux/Mac) |
 | [`recursive_mutex`](src/rpp/mutex.h#L35) | Recursive mutex variant |
 | [`unlock_guard<Mutex>`](src/rpp/mutex.h#L172) | RAII unlock guard: unlocks on construction, relocks on destruction |
-| [`synchronized<T>`](src/rpp/mutex.h#L411) | Thread-safe value wrapper, accessed via `sync()` → `synchronize_guard` |
+| [`synchronized<T>`](src/rpp/mutex.h#L410) | Thread-safe value wrapper, accessed via `sync()` → `synchronize_guard` |
 
 ### Free Functions
 
@@ -4682,18 +4684,20 @@ See [`log_colors.h`](https://github.com/RedFox20/ReCpp/blob/master/src/rpp/log_c
 
 ## rpp/type_traits.h
 
-Detection idiom and type trait helpers for SFINAE.
+C++20 concepts, and the detection idiom for a caller which brings its own expression alias.
 
 | Trait | Description |
 |-------|-------------|
-| [`is_detected<Op, Args...>`](src/rpp/type_traits.h#L26) | Detection idiom |
-| [`has_to_string<T>`](src/rpp/type_traits.h#L40) | True if `to_string(T)` is valid |
+| [`is_detected<Op, Args...>`](src/rpp/type_traits.h#L27) | Detection idiom, for an alias the caller writes |
+| [`has_to_string<T>`](src/rpp/type_traits.h#L38) | True if `to_string(T)` is valid |
 | [`has_to_string_memb<T>`](src/rpp/type_traits.h#L41) | True if `T::to_string()` exists |
-| [`has_std_to_string<T>`](src/rpp/type_traits.h#L38) | True if `std::to_string(T)` is valid |
+| [`has_std_to_string<T>`](src/rpp/type_traits.h#L34) | True if `std::to_string(T)` is valid |
+| [`has_get_memb<T>`](src/rpp/type_traits.h#L44) | True if `T::get()` exists |
+| [`has_set_memb<T, U>`](src/rpp/type_traits.h#L47) | True if `T::set(U)` exists |
 | [`is_iterable<T>`](src/rpp/type_traits.h#L50) | True if T supports range-for |
-| [`is_container<T>`](src/rpp/type_traits.h#L55) | True if T is a container with `size()` |
+| [`is_container<T>`](src/rpp/type_traits.h#L56) | True if T is a container with `size()` |
 | [`is_stringlike<T>`](src/rpp/type_traits.h#L53) | True if T is string-like |
-| [`Operation`](src/rpp/type_traits.h#L25) | Template alias used with `is_detected` for expression validity checks |
+| [`Operation`](src/rpp/type_traits.h#L26) | The expression alias a caller passes to `is_detected` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4687,12 +4687,12 @@ Detection idiom and type trait helpers for SFINAE.
 | Trait | Description |
 |-------|-------------|
 | [`is_detected<Op, Args...>`](src/rpp/type_traits.h#L26) | Detection idiom |
-| [`has_to_string<T>`](src/rpp/type_traits.h#L42) | True if `to_string(T)` is valid |
-| [`has_to_string_memb<T>`](src/rpp/type_traits.h#L43) | True if `T::to_string()` exists |
-| [`has_std_to_string<T>`](src/rpp/type_traits.h#L40) | True if `std::to_string(T)` is valid |
-| [`is_iterable<T>`](src/rpp/type_traits.h#L52) | True if T supports range-for |
-| [`is_container<T>`](src/rpp/type_traits.h#L57) | True if T is a container with `size()` |
-| [`is_stringlike<T>`](src/rpp/type_traits.h#L55) | True if T is string-like |
+| [`has_to_string<T>`](src/rpp/type_traits.h#L40) | True if `to_string(T)` is valid |
+| [`has_to_string_memb<T>`](src/rpp/type_traits.h#L41) | True if `T::to_string()` exists |
+| [`has_std_to_string<T>`](src/rpp/type_traits.h#L38) | True if `std::to_string(T)` is valid |
+| [`is_iterable<T>`](src/rpp/type_traits.h#L50) | True if T supports range-for |
+| [`is_container<T>`](src/rpp/type_traits.h#L55) | True if T is a container with `size()` |
+| [`is_stringlike<T>`](src/rpp/type_traits.h#L53) | True if T is string-like |
 | [`Operation`](src/rpp/type_traits.h#L25) | Template alias used with `is_detected` for expression validity checks |
 
 ---

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -1,6 +1,6 @@
 # ReCpp C++20 Modules Migration Plan
 
-Revision 9. Twenty-four modules exist: all of L0 and L1, and six of the eight in L2.
+Revision 10. Twenty-six modules exist: all of L0, L1 and L2.
 
 This document explains the pattern, records what real builds prove about it, and
 gives the phased plan for the remaining 20 headers.
@@ -12,39 +12,35 @@ gate, #65 changeset 6.
 
 | Item | State |
 |---|---|
-| the twenty-four modules | build and pass on gcc-14, and CI covers clang-21 and MSVC 14.52 |
+| the twenty-six modules | build and pass on gcc-14, and CI covers clang-21 and MSVC 14.52 |
 | `debugging.macros.h` | split out, 50 preprocessed lines against 32893 |
 | `BUILD_WITH_MODULES=AUTO` | on per toolchain, GCC 14 / Clang 21 / MSVC 19.34 |
 | Include-order style rule | in AGENTS.md, and the `import-order` gate holds it |
 | `tools/check_includes.py` | 6 checks. 4 gate CI, and `missing` and `unused` stay ungated |
-| `tests/test_modules.cpp` | module consumer test, 21 cases. It includes `tests.h` and the macro header only, so what those two mask needs a module-only target |
+| `tests/test_modules.cpp` | module consumer test, 23 cases. It includes `tests.h` and the macro header only, so what those two mask needs a module-only target |
 | `tests/module_consumer/` | a real mama consumer, on gcc, clang and MSVC, with 4 module-only targets |
 | mama | 0.14.0 exports the `.cppm` files and strips the module objects |
 | CI | 28 jobs on GitHub Actions, and CircleCI is gone |
-| test counts | 552/552 on the modules build, 531/531 on the header build |
+| test counts | 556/556 on the modules build, 533/533 on the header build |
 
 **Changeset state:** 1a is dropped, see section 4. 1b, 2, 3 and the mama half of
-6 landed. The generator drives all twenty-four modules. 4 is done through the generator
-`--check`. 5 has L0 and L1 finished, and L2 ships six of eight. Section 11 lists what 7 owes.
+6 landed. The generator drives all twenty-six modules. 4 is done through the generator
+`--check`. 5 has L0, L1 and L2 finished. Section 11 lists what 7 owes.
 
-**Next action, and it outranks the remaining layers: land `rpp.sprint`.** `sprint.h` carries
-`string_buffer`, `format` and every `to_string` overload, so more code depends on it than on
-any other L2 header. gcc-14 writes its module and no importer reads it back, which `BUGS.md`
-**B8** records with a reproducer. Answer three questions in order.
+**Next:** changeset 5, the L3 layer. Section 9 has the layers.
 
-1. Does clang-21 import `rpp.sprint`? CI runs that toolchain, and this machine carries
-   clang-18, which cannot build modules at all. A green clang-21 import makes B8 a gcc bug
-   and nothing more.
-2. Does a gcc newer than 14.2 import it? The failure names `std::_Mutex_base`, so a
-   libstdc++ or module-writer fix may already exist upstream.
-3. If both fail, cut the module surface until it reads back. `sprint.h` re-exports four
-   modules, which is more than any other L2 header, and a smaller export set narrows the
-   BMI that gcc cannot write.
+**`rpp.sprint` and `rpp.task` ship, and each cost one workaround.** The generator carries
+`NO_EXPORT` and `NO_IMPORT`, one entry each, and `BUGS.md` **B8** names the two shapes gcc-14
+cannot write. Neither one is a wrong export list, and the generator selftest pins both knobs.
 
-`rpp.task` fails the same way and waits behind the same three questions. It blocks less,
-because only the coroutine headers name it.
+An `is_detected_v` alias which names `std::to_string` was the first shape, so the C++20
+concept replaced it. That did not help. A plain alias, a concept, and a concept which calls an
+unexported helper all fail the same way. The export reaches a `std::__cxx11` function either
+way. Only dropping the export works, so `has_std_to_string` left the module surface.
+The concept stayed, because it reads better and skips one `is_detected_v` instantiation.
 
-**Then:** changeset 5, the L3 layer. Section 9 has the layers.
+Delete a `NO_EXPORT` or `NO_IMPORT` entry when a newer gcc reads the module back. The B8
+reproducer builds every `.cppm` into one `gcm.cache` outside cmake, which answers in seconds.
 
 **What L1 and L2 exposed.** Six headers declared public API the compiler could not export,
 and each fix landed with the layer. `math.h` marked every function `static` and left its
@@ -82,10 +78,9 @@ only it can offer, the vector overload an explicit `rpp::sort<T>(v)` names, and 
 `element_range` overload whose by-value parameter lets a const view sort its mutable
 elements. Asking which module should carry a name is worth doing per layer.
 
-**Open questions:** `BUGS.md` B2, B5, B6 and B8. B2 and B6 reach this work through CI only.
-B6 costs the most. It failed 6 of the 40 TSAN jobs this branch ran, which is 15 percent per
-job, and 5 TSAN jobs per run puts a red job in more than half of all runs. Every one passed
-every test and failed on the sanitizer exit code alone.
+**Open questions:** `BUGS.md` B2, B5, B9 and B10. B8 keeps its two workarounds open, and each
+one goes away when a newer gcc reads the module back. B6 closed as C25, so the TSAN jobs no
+longer fail on the exception refcount race.
 
 ---
 
@@ -774,7 +769,7 @@ of `src/rpp/*.h`, so changeset 1b can move a header between layers.
 |---|---|---|
 | L0 | **config.types** ✓, **minmax** ✓, **obfuscated_string** ✓, **scope_guard** ✓ | 4 |
 | L1 | **bitutils** ✓, **debugging** ✓, **delegate** ✓, **endian** ✓, **future_types** ✓, **math** ✓, **predicates** ✓, **proc_utils** ✓, **sort** ✓, **source_loc** ✓, **strview** ✓, **timepoint** ✓, **traits** ✓, **type_traits** ✓ | 14 |
-| L2 | **atomic_timepoint** ✓, **collections** ✓, sprint ⚠, **stack_trace** ✓, task ⚠, **threads** ✓, **timer** ✓, **vec** ✓ | 8 |
+| L2 | **atomic_timepoint** ✓, **collections** ✓, **sprint** ✓, **stack_trace** ✓, **task** ✓, **threads** ✓, **timer** ✓, **vec** ✓ | 8 |
 | L3 | load_balancer, memory_pool, mutex, paths, tests | 5 |
 | L4 | atomic_shared_ptr, close_sync, condition_variable, file_io, sockets | 5 |
 | L5 | binary_stream, concurrent_queue, semaphore | 3 |
@@ -783,7 +778,7 @@ of `src/rpp/*.h`, so changeset 1b can move a header between layers.
 | L8 | coroutines | 1 |
 | top | umbrella `rpp` | 1 |
 
-A ⚠ marks a module gcc-14 writes but no importer reads, which `BUGS.md` **B8** tracks.
+Every L2 module ships. `BUILD_WITH_MODULES` builds all twenty-six.
 
 44 modules and one umbrella. L0, L1 and six of L2 exist, so 20 remain. Excluded:
 `config.h` and `log_colors.h` by rule 1 of section 6.3, and `jni_cpp.h` because

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -3,7 +3,7 @@
 Revision 10. Twenty-six modules exist: all of L0, L1 and L2.
 
 This document explains the pattern, records what real builds prove about it, and
-gives the phased plan for the remaining 20 headers.
+gives the phased plan for the remaining 18 headers.
 
 ## Handover state
 
@@ -21,7 +21,7 @@ gate, #65 changeset 6.
 | `tests/module_consumer/` | a real mama consumer, on gcc, clang and MSVC, with 4 module-only targets |
 | mama | 0.14.0 exports the `.cppm` files and strips the module objects |
 | CI | 28 jobs on GitHub Actions, and CircleCI is gone |
-| test counts | 556/556 on the modules build, 533/533 on the header build |
+| test counts | 557/557 on the modules build, 534/534 on the header build |
 
 **Changeset state:** 1a is dropped, see section 4. 1b, 2, 3 and the mama half of
 6 landed. The generator drives all twenty-six modules. 4 is done through the generator
@@ -31,7 +31,8 @@ gate, #65 changeset 6.
 
 **`rpp.sprint` and `rpp.task` ship, and each cost one workaround.** The generator carries
 `NO_EXPORT` and `NO_IMPORT`, one entry each, and `BUGS.md` **B8** names the two shapes gcc-14
-cannot write. Neither one is a wrong export list, and the generator selftest pins both knobs.
+cannot write. `NO_CONFIG` names the third case, a header which does not compile bare metal at
+all. Neither shape is a wrong export list, and the generator selftest pins all three knobs.
 
 An `is_detected_v` alias which names `std::to_string` was the first shape, so the C++20
 concept replaced it. That did not help. A plain alias, a concept, and a concept which calls an
@@ -780,7 +781,7 @@ of `src/rpp/*.h`, so changeset 1b can move a header between layers.
 
 Every L2 module ships. `BUILD_WITH_MODULES` builds all twenty-six.
 
-44 modules and one umbrella. L0, L1 and six of L2 exist, so 20 remain. Excluded:
+44 modules and one umbrella. L0, L1 and L2 exist, so 18 remain. Excluded:
 `config.h` and `log_colors.h` by rule 1 of section 6.3, and `jni_cpp.h` because
 it is Android glue. `tests.h` is in, and it is the one header whose macros split
 into `tests_macros.h`.

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -21,7 +21,7 @@ gate, #65 changeset 6.
 | `tests/module_consumer/` | a real mama consumer, on gcc, clang and MSVC, with 4 module-only targets |
 | mama | 0.14.0 exports the `.cppm` files and strips the module objects |
 | CI | 28 jobs on GitHub Actions, and CircleCI is gone |
-| test counts | 557/557 on the modules build, 534/534 on the header build |
+| test counts | 561/561 on the modules build, 538/538 on the header build |
 
 **Changeset state:** 1a is dropped, see section 4. 1b, 2, 3 and the mama half of
 6 landed. The generator drives all twenty-six modules. 4 is done through the generator

--- a/src/rpp/binary_stream.h
+++ b/src/rpp/binary_stream.h
@@ -224,7 +224,7 @@ namespace rpp
                                              && std::is_trivially_destructible<T>::value;
 
         /** @brief Writes object of type T into the buffer */
-        template<class T, typename = std::enable_if_t<is_trivial_type<T>>> 
+        template<class T> requires is_trivial_type<T>
         binary_stream& write(const T& data) noexcept
         {
             ensure_space((int)sizeof(T));

--- a/src/rpp/delegate.h
+++ b/src/rpp/delegate.h
@@ -238,7 +238,11 @@ namespace rpp
 
         // not const delegate& or delegate&&
         template<class FunctionType>
-        using enable_if_not_copy_ctor_t = std::enable_if_t< !std::is_same_v<std::decay_t<FunctionType>, delegate> >;
+        static constexpr bool not_copy_ctor = !std::is_same_v<std::decay_t<FunctionType>, delegate>;
+
+        // the member constructors take the method arguments verbatim, and the adapters take the rest
+        template<class...TArgs>
+        static constexpr bool args_match = std::is_same_v<std::tuple<TArgs...>, std::tuple<Args...>>;
 
         template<class Function>
         static constexpr bool is_func_type = std::is_same_v<Function, func_type>;
@@ -253,7 +257,7 @@ namespace rpp
          * @brief Master constructor for most delegate types
          *        Matches: functors, lambdas, global functions
          */
-        template<class FunctionType, typename = enable_if_not_copy_ctor_t<FunctionType>>
+        template<class FunctionType> requires not_copy_ctor<FunctionType>
         delegate(FunctionType&& function) noexcept
         {
             using Function = typename std::decay_t<FunctionType>;
@@ -275,7 +279,7 @@ namespace rpp
         }
 
         /** @brief Basic operator= shortcut for reset() */
-        template<class FunctionType, typename = enable_if_not_copy_ctor_t<FunctionType>>
+        template<class FunctionType> requires not_copy_ctor<FunctionType>
         DELEGATE_FINLINE delegate& operator=(FunctionType&& function) noexcept
         {
             reset(std::forward<FunctionType>(function));
@@ -283,7 +287,7 @@ namespace rpp
         }
 
         /** @brief Generic init which catches: functors, lambdas, global funcs */
-        template<class FunctionType, typename = enable_if_not_copy_ctor_t<FunctionType>>
+        template<class FunctionType> requires not_copy_ctor<FunctionType>
         void reset(FunctionType&& function) noexcept
         {
             reset();
@@ -470,8 +474,7 @@ namespace rpp
          *   delegate<void(int)> d(&myClass, &MyClass::method);
          * @endcode
          */
-        template<class IClass, class FClass, class...TArgs,
-                 std::enable_if_t<std::is_same_v<std::tuple<TArgs...>, std::tuple<Args...>>, int> = 0>
+        template<class IClass, class FClass, class...TArgs> requires args_match<TArgs...>
         delegate(IClass* inst, Ret (FClass::*method)(TArgs...))
         {
             if (!inst) throw std::invalid_argument{"delegate ctor: inst is nullptr"};
@@ -484,8 +487,7 @@ namespace rpp
          *   delegate<void(int)> d(&myClass, &MyClass::method);
          * @endcode
          */
-        template<class IClass, class FClass, class...TArgs,
-                 std::enable_if_t<std::is_same_v<std::tuple<TArgs...>, std::tuple<Args...>>, int> = 0>
+        template<class IClass, class FClass, class...TArgs> requires args_match<TArgs...>
         delegate(const IClass* inst, Ret (FClass::*method)(TArgs...) const)
         {
             if (!inst) throw std::invalid_argument{"delegate ctor: inst is nullptr"};
@@ -513,8 +515,7 @@ namespace rpp
          *   delegate<void(int)> d(&myClass, &MyClass::method);
          * @endcode
          */
-        template<class IClass, class FClass, class...TArgs,
-                 std::enable_if_t<!std::is_same_v<std::tuple<TArgs...>, std::tuple<Args...>>, int> = 0>
+        template<class IClass, class FClass, class...TArgs> requires (!args_match<TArgs...>)
         delegate(IClass* inst, Ret (FClass::*method)(TArgs...)) : delegate{}
         {
             if (!inst) throw std::invalid_argument{"delegate ctor: inst is nullptr"};
@@ -527,8 +528,7 @@ namespace rpp
          *   delegate<void(int)> d(&myClass, &MyClass::method);
          * @endcode
          */
-        template<class IClass, class FClass, class...TArgs,
-                 std::enable_if_t<!std::is_same_v<std::tuple<TArgs...>, std::tuple<Args...>>, int> = 0>
+        template<class IClass, class FClass, class...TArgs> requires (!args_match<TArgs...>)
         delegate(const IClass* inst, Ret (FClass::*method)(TArgs...) const) : delegate{}
         {
             if (!inst) throw std::invalid_argument{"delegate ctor: inst is nullptr"};

--- a/src/rpp/mutex.h
+++ b/src/rpp/mutex.h
@@ -331,32 +331,31 @@ namespace rpp
             return instance->get_ref() != other;
         }
 
-        template<typename U = value_type>
-        std::enable_if_t<is_iterable<U>, decltype(std::declval<U>().begin())>
+        template<typename U = value_type> requires is_iterable<U>
+        decltype(std::declval<U>().begin())
         begin() {
             return instance->get_ref().begin();
         }
 
-        template<typename U = value_type>
-        std::enable_if_t<is_iterable<U>, decltype(std::declval<U>().end())>
+        template<typename U = value_type> requires is_iterable<U>
+        decltype(std::declval<U>().end())
         end() {
             return instance->get_ref().end();
         }
 
-        template<typename U = value_type>
-        std::enable_if_t<is_iterable<U>, decltype(std::declval<const U>().begin())>
+        template<typename U = value_type> requires is_iterable<U>
+        decltype(std::declval<const U>().begin())
         begin() const {
             return static_cast<const U&>(instance->get_ref()).begin();
         }
 
-        template<typename U = value_type>
-        std::enable_if_t<is_iterable<U>, decltype(std::declval<const U>().end())>
+        template<typename U = value_type> requires is_iterable<U>
+        decltype(std::declval<const U>().end())
         end() const {
             return static_cast<const U&>(instance->get_ref()).end(); 
         }
 
-        template<class U = value_type, class V,
-                 std::enable_if_t<rpp::is_iterable<U>, int> = 0>
+        template<class U = value_type, class V> requires rpp::is_iterable<U>
         FINLINE void operator=(std::initializer_list<V> value)
         {
             this->operator=(U{value});

--- a/src/rpp/rpp-sprint.cppm
+++ b/src/rpp/rpp-sprint.cppm
@@ -14,6 +14,8 @@ export namespace rpp {
     using rpp::lowercase;
     using rpp::uppercase;
     using rpp::string_buffer;
+    using rpp::has_ostream_op;
+    using rpp::has_member_sbuf_op;
     using rpp::operator<<;
     using rpp::to_hex_string;
     using rpp::print;

--- a/src/rpp/rpp-sprint.cppm
+++ b/src/rpp/rpp-sprint.cppm
@@ -1,0 +1,25 @@
+module;
+#include "sprint.h"
+export module rpp.sprint;
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+export import rpp.debugging;
+export import rpp.strview;
+export import rpp.type_traits;
+
+export namespace rpp {
+    using rpp::to_string;
+    using rpp::format_opt;
+    using rpp::none;
+    using rpp::lowercase;
+    using rpp::uppercase;
+    using rpp::string_buffer;
+    using rpp::operator<<;
+    using rpp::to_hex_string;
+    using rpp::print;
+    using rpp::println;
+    using rpp::sprint;
+    using rpp::sprintln;
+    using rpp::format;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-task.cppm
+++ b/src/rpp/rpp-task.cppm
@@ -1,0 +1,26 @@
+// C++20 module interface unit for <rpp/task.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "task.h"
+
+export module rpp.task;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+
+export namespace rpp {
+#if RPP_HAS_COROUTINES
+    using rpp::task;
+    using rpp::deferred;
+#endif
+}
+
+export namespace rpp::detail {
+#if RPP_HAS_COROUTINES
+    using rpp::detail::task_final_awaiter;
+    using rpp::detail::take_result;
+    using rpp::detail::task_promise;
+    using rpp::detail::task_base;
+#endif
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-type_traits.cppm
+++ b/src/rpp/rpp-type_traits.cppm
@@ -12,18 +12,10 @@ export import rpp.config;
 export namespace rpp {
     using rpp::is_detected;
     using rpp::is_detected_v;
-    using rpp::to_string_expression;
-    using rpp::to_string_memb_expression;
-    using rpp::get_memb_expression;
-    using rpp::set_memb_expression;
     using rpp::has_to_string;
     using rpp::has_to_string_memb;
     using rpp::has_get_memb;
     using rpp::has_set_memb;
-    using rpp::has_begin_expression;
-    using rpp::has_end_expression;
-    using rpp::has_size_expression;
-    using rpp::has_c_str_expression;
     using rpp::is_iterable;
     using rpp::is_stringlike;
     using rpp::is_container;

--- a/src/rpp/rpp-type_traits.cppm
+++ b/src/rpp/rpp-type_traits.cppm
@@ -27,10 +27,6 @@ export namespace rpp {
     using rpp::is_iterable;
     using rpp::is_stringlike;
     using rpp::is_container;
-#if !RPP_BARE_METAL
-    using rpp::std_to_string_expression;
-    using rpp::has_std_to_string;
-#endif
 }
 
 export namespace rpp::detail {

--- a/src/rpp/sprint.h
+++ b/src/rpp/sprint.h
@@ -70,6 +70,14 @@ namespace rpp
         uppercase,
     };
 
+    struct string_buffer;
+
+    /// True when `std::ostream << T` compiles
+    template<class T> concept has_ostream_op = requires(std::ostream& os) { os << std::declval<T>(); };
+
+    /// True when `T::operator<<(string_buffer&)` compiles
+    template<class T> concept has_member_sbuf_op = requires(string_buffer& sb) { std::declval<const T&>().operator<<(sb); };
+
     /**
      * Always null terminated version of stringstream, which is compatible with strview
      * Not intended for moving or copying
@@ -223,15 +231,6 @@ namespace rpp
         // needs to be duplicated due to operator<< not being able to detect the correct overload
         template<class T> FINLINE void write(T* ptr) noexcept { write_ptr_type(ptr); }
 
-        // For: std::ostream& operator<<(std::ostream& os, const T& value);
-        template<class T> using ostrm_op = decltype(std::declval<std::ostream&>() << std::declval<T>());
-        
-        // For: string_buffer& operator<<(string_buffer& sb, const T& value);
-        // template<class T> using sbuf_op = decltype(std::declval<string_buffer&>() << std::declval<T>());
-
-        // For: T::operator<<(rpp::string_buffer&) const;
-        template<class T> using member_sbuf_op = decltype(std::declval<const T&>().operator<<(std::declval<string_buffer&>()));
-
         /**
          * @brief Generic fallback for unknown types. Tries different ways to convert T to string
          */
@@ -240,7 +239,7 @@ namespace rpp
             // this part is a bit dangerous, there is a possibility for cyclic recursion
             // if we call *this << value, which calls write(value)
             // so only value.operator<< is allowed
-            if constexpr (is_detected_v<member_sbuf_op, T>)
+            if constexpr (has_member_sbuf_op<T>)
             {
                 value.operator<<(*this); // member operator<<
             }
@@ -256,7 +255,7 @@ namespace rpp
             {
                 this->write(std::to_string(value));
             }
-            else if constexpr (is_detected_v<ostrm_op, T>)
+            else if constexpr (has_ostream_op<T>)
             {
                 std::ostringstream oss;
                 oss << value;
@@ -587,7 +586,7 @@ namespace rpp
      *  [2] = { "key": "value", "name": "john" }
      *  @endcode
      */
-    template<typename C, std::enable_if_t<is_container<C>, int> = 0>
+    template<is_container C>
     NOINLINE std::string to_string(const C& container, bool newlines = true) noexcept
     {
         rpp::string_buffer sb; sb.write_cont(container, newlines); return sb.str();

--- a/src/rpp/type_traits.h
+++ b/src/rpp/type_traits.h
@@ -28,16 +28,14 @@ namespace rpp
     template<template<class...> class Operation, typename... Arguments>
     inline constexpr bool is_detected_v = detail::is_detected<detail::void_t<>, Operation, Arguments...>::value;
 
-#if !RPP_BARE_METAL
-    template<class T> using std_to_string_expression  = decltype(std::to_string(std::declval<T>()));
-#endif
     template<class T> using to_string_expression      = decltype(to_string(std::declval<T>()));
     template<class T> using to_string_memb_expression = decltype(std::declval<T>().to_string());
     template<class T> using get_memb_expression       = decltype(std::declval<T>().get());
     template<class T, class U> using set_memb_expression = decltype(std::declval<T>().set(std::declval<U>()));
 
 #if !RPP_BARE_METAL
-    template<class T> inline constexpr bool has_std_to_string  = is_detected_v<std_to_string_expression, T>;
+    /// True when `std::to_string(T)` compiles
+    template<class T> concept has_std_to_string = requires { std::to_string(std::declval<T>()); };
 #endif
     template<class T> inline constexpr bool has_to_string      = is_detected_v<to_string_expression, T>;
     template<class T> inline constexpr bool has_to_string_memb = is_detected_v<to_string_memb_expression, T>;

--- a/src/rpp/type_traits.h
+++ b/src/rpp/type_traits.h
@@ -22,39 +22,39 @@ namespace rpp
         struct is_detected<void_t<Operation<Arguments...>>, Operation, Arguments...> : std::true_type {};
     }
 
+    // the traits below are concepts. This stays for a consumer which brings its own alias
     template<template<class...> class Operation, typename... Arguments>
     using is_detected = detail::is_detected<detail::void_t<>, Operation, Arguments...>;
 
     template<template<class...> class Operation, typename... Arguments>
     inline constexpr bool is_detected_v = detail::is_detected<detail::void_t<>, Operation, Arguments...>::value;
 
-    template<class T> using to_string_expression      = decltype(to_string(std::declval<T>()));
-    template<class T> using to_string_memb_expression = decltype(std::declval<T>().to_string());
-    template<class T> using get_memb_expression       = decltype(std::declval<T>().get());
-    template<class T, class U> using set_memb_expression = decltype(std::declval<T>().set(std::declval<U>()));
-
 #if !RPP_BARE_METAL
     /// True when `std::to_string(T)` compiles
     template<class T> concept has_std_to_string = requires { std::to_string(std::declval<T>()); };
 #endif
-    template<class T> inline constexpr bool has_to_string      = is_detected_v<to_string_expression, T>;
-    template<class T> inline constexpr bool has_to_string_memb = is_detected_v<to_string_memb_expression, T>;
-    template<class T> inline constexpr bool has_get_memb       = is_detected_v<get_memb_expression, T>;
-    template<class T, class U> inline constexpr bool has_set_memb = is_detected_v<set_memb_expression, T, U>;
 
-    template<class T> using has_begin_expression  = decltype(std::declval<T>().begin());
-    template<class T> using has_end_expression    = decltype(std::declval<T>().end());
-    template<class T> using has_size_expression   = decltype(std::declval<T>().size());
-    template<class T> using has_c_str_expression  = decltype(std::declval<T>().c_str());
+    /// True when an ADL `to_string(T)` compiles
+    template<class T> concept has_to_string = requires { to_string(std::declval<T>()); };
 
-    template<class T> inline constexpr bool is_iterable = is_detected_v<has_begin_expression, T>
-                                                && is_detected_v<has_end_expression, T>;
+    /// True when `T::to_string()` compiles
+    template<class T> concept has_to_string_memb = requires { std::declval<T>().to_string(); };
 
-    template<class T> inline constexpr bool is_stringlike = is_detected_v<has_c_str_expression, T>;
+    /// True when `T::get()` compiles
+    template<class T> concept has_get_memb = requires { std::declval<T>().get(); };
 
-    template<class T> inline constexpr bool is_container = is_iterable<T>
-                                                 && is_detected_v<has_size_expression, T>
-                                                 && !is_stringlike<T>;
+    /// True when `T::set(U)` compiles
+    template<class T, class U> concept has_set_memb = requires { std::declval<T>().set(std::declval<U>()); };
+
+    /// True when T supports range-for
+    template<class T> concept is_iterable = requires { std::declval<T>().begin(); std::declval<T>().end(); };
+
+    /// True when `T::c_str()` compiles
+    template<class T> concept is_stringlike = requires { std::declval<T>().c_str(); };
+
+    /// True when T iterates and reports a size, and does not look like a string
+    template<class T> concept is_container = is_iterable<T> && !is_stringlike<T>
+                                          && requires { std::declval<T>().size(); };
 
     // ------------------------------------------------------------------------------------ //
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -13,15 +13,8 @@
     #endif
 #endif
 
-// TSAN cannot see the future refcount inside the uninstrumented libc++.so, so a promise
-// destroyed after the waiter released looks like a race. See BUGS.md C15.
-#if defined(__clang__) && defined(__has_feature)
-    #if __has_feature(thread_sanitizer)
-        extern "C" const char* __tsan_default_suppressions() { // NOLINT(bugprone-reserved-identifier)
-            return "race:std::__1::promise\n"; // libc++ puts every promise in namespace __1
-        }
-    #endif
-#endif
+// tests/test_sanitizers.cpp owns __tsan_default_suppressions, beside the test which proves
+// libtsan.so can reach it
 
 static bool is_verbose(int argc, char** argv)
 {

--- a/tests/module_consumer/CMakeLists.txt
+++ b/tests/module_consumer/CMakeLists.txt
@@ -28,6 +28,8 @@ mama_target_modules(RppMinmaxModuleOnly)
 add_executable(RppMaskedModuleOnly masked_module_only.cpp)
 target_include_directories(RppMaskedModuleOnly PRIVATE ${MAMA_INCLUDES})
 mama_target_modules(RppMaskedModuleOnly)
+# sprint.cpp holds the out-of-line half of rpp.sprint, so this target links the library
+target_link_libraries(RppMaskedModuleOnly PRIVATE ${MAMA_LIBS})
 
 # rpp::sort has to reach an importer of rpp.sort, without rpp.collections beside it
 add_executable(RppSortModuleOnly sort_module_only.cpp)

--- a/tests/module_consumer/masked_module_only.cpp
+++ b/tests/module_consumer/masked_module_only.cpp
@@ -10,10 +10,13 @@ import rpp.future_types;
 import rpp.math;
 import rpp.sprint;
 
+// is_detected takes the alias of whoever calls it, so this proves the idiom, not one alias
+template<class T> using has_size = decltype(std::declval<T>().size());
+
 int main()
 {
-    // type_traits: the alias templates and the variable templates that read them
-    bool detected = rpp::is_detected_v<rpp::has_size_expression, std::string>
+    // type_traits: the concepts, and the detection idiom a consumer drives with its own alias
+    bool detected = rpp::is_detected_v<has_size, std::string>
                  && rpp::is_stringlike<std::string>
                  && rpp::is_container<std::vector<int>>
                  && rpp::is_iterable<std::vector<int>>;

--- a/tests/module_consumer/masked_module_only.cpp
+++ b/tests/module_consumer/masked_module_only.cpp
@@ -2,6 +2,7 @@
 // of them drops an export. tests/test_modules.cpp cannot prove these four.
 #ifdef MAMA_HAS_MODULES
 #include <string>
+#include <utility> // std::declval
 #include <vector>
 
 import rpp.type_traits; // includes come first, the imports go last

--- a/tests/module_consumer/masked_module_only.cpp
+++ b/tests/module_consumer/masked_module_only.cpp
@@ -8,6 +8,7 @@ import rpp.type_traits; // includes come first, the imports go last
 import rpp.source_loc;
 import rpp.future_types;
 import rpp.math;
+import rpp.sprint;
 
 int main()
 {
@@ -29,7 +30,13 @@ int main()
     bool numeric = rpp::clamp(5, 0, 3) == 3 && rpp::lerp(0.5, 30.0, 60.0) == 45.0
                 && rpp::nearlyZero(0.0001) && rpp::PI > 3.14;
 
-    return (detected && located && typed && numeric) ? 0 : 1;
+    // sprint: the buffer, the free functions and the container formatting all come from the module
+    rpp::string_buffer sb;
+    sb << "v=" << std::vector<int>{ 1, 2 };
+    bool printed = rpp::sprint(1, "and", 2.5) == "1 and 2.5" && sb.view() == "v={ 1, 2 }"
+                && rpp::to_string('x') == "x" && rpp::format("%d", 7) == "7";
+
+    return (detected && located && typed && numeric && printed) ? 0 : 1;
 }
 #else
 int main() { return 0; } // the header build does not exercise the module

--- a/tests/test_delegate.cpp
+++ b/tests/test_delegate.cpp
@@ -186,6 +186,81 @@ namespace rpp
             AssertThat(func2(data), "const_method");
         }
 
+        // reset() shares the not_copy_ctor constraint with the master constructor,
+        // and it dispatches the same three ways
+        TestCase(reset_takes_every_callable_shape)
+        {
+            Data (*function)(Data a) = [](Data a) { return validate("function", a); };
+
+            DataDelegate func;
+            func.reset(function); // function pointer
+            AssertThat(func(data), "function");
+
+            func.reset([](Data a) { return validate("lambda", a); }); // functor
+            AssertThat(func(data), "lambda");
+
+            Derived inst;
+            func.reset(&inst, &Derived::method); // member overload, not the template
+            AssertThat(func(data), "method");
+            func.reset(&inst, &Derived::const_method);
+            AssertThat(func(data), "const_method");
+
+            func.reset(nullptr);
+            AssertThat(func.good(), false);
+        }
+
+        // not_copy_ctor keeps a delegate argument out of the master constructor, which would
+        // otherwise beat the copy constructor for a non-const lvalue
+        TestCase(copy_construction_prefers_the_copy_constructor)
+        {
+            DataDelegate original = [](Data a) { return validate("original", a); };
+
+            DataDelegate from_lvalue { original };
+            AssertThat(from_lvalue(data), "original");
+            AssertThat(original.good(), true); // the copy left the source intact
+
+            const DataDelegate& cref = original;
+            DataDelegate from_const_lvalue { cref };
+            AssertThat(from_const_lvalue(data), "original");
+
+            DataDelegate from_rvalue { std::move(original) };
+            AssertThat(from_rvalue(data), "original");
+        }
+
+        // the same constraint on operator=, driven from the callable side
+        TestCase(assignment_takes_every_callable_shape)
+        {
+            Data (*function)(Data a) = [](Data a) { return validate("function", a); };
+
+            DataDelegate func;
+            func = function;
+            AssertThat(func(data), "function");
+
+            func = [](Data a) { return validate("lambda", a); };
+            AssertThat(func(data), "lambda");
+
+            func = nullptr;
+            AssertThat(func.good(), false);
+        }
+
+        // only the const-instance constructors accept a const object, and args_match picks
+        // the direct call or the adapter between them
+        TestCase(const_instance_binds_the_const_method_constructors)
+        {
+            const Derived inst;
+            DataDelegate direct { &inst, &Derived::const_method }; // args match exactly
+            AssertThat(direct(data), "const_method");
+
+            const ConstRefAdapterClass obj;
+            rpp::delegate<void(int val)> adapted { &obj, &ConstRefAdapterClass::cref_const_method };
+            adapted(42); // const int& against int, so this one takes the adapter
+            AssertThat(obj.result, 42);
+
+            rpp::delegate<void(int val)> exact { &obj, &ConstRefAdapterClass::byval_const_method };
+            exact(89);
+            AssertThat(obj.result, 89);
+        }
+
         TestCase(virtuals)
         {
             Base    base;

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -33,7 +33,7 @@ import rpp.task;
 import rpp.vec;
 
 // test_modules_identity.cpp takes this address through the module and includes no rpp header
-const void* module_is_container_addr() noexcept;
+const void* module_pi_addr() noexcept;
 
 TestImpl(test_modules)
 {
@@ -122,11 +122,11 @@ TestImpl(test_modules)
         AssertThat(bits.isSet(4), false);
     }
 
-    // a variable template needs `inline`, or gcc gives the module and the header one copy each
-    TestCase(type_traits_variable_template_is_one_entity)
+    // a namespace-scope constant needs `inline`, or the module and the header get one copy each
+    TestCase(math_constant_is_one_entity)
     {
-        const void* header = &rpp::is_container<std::vector<int>>;
-        AssertThat(module_is_container_addr() == header, true);
+        const void* header = &rpp::PI;
+        AssertThat(module_pi_addr() == header, true);
     }
 
     TestCase(traits_module_carries_the_whole_surface)

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -28,6 +28,8 @@ import rpp.collections;
 import rpp.stack_trace;
 import rpp.threads;
 import rpp.timer;
+import rpp.sprint;
+import rpp.task;
 import rpp.vec;
 
 // test_modules_identity.cpp takes this address through the module and includes no rpp header
@@ -278,6 +280,31 @@ TestImpl(test_modules)
         rpp::Vector2 p { 3.0f, 4.0f };
         AssertThat(p.length(), 5.0f);
     }
+
+    TestCase(sprint_module_carries_the_whole_surface)
+    {
+        AssertThat(rpp::sprint(1, "and", 2.5), "1 and 2.5"); // sprint separates the arguments
+        AssertThat(rpp::to_string('x'), "x");
+        AssertThat(rpp::to_hex_string(rpp::strview{"AB"}), "4142");
+
+        rpp::string_buffer sb;
+        sb << "n=" << 42 << " v=" << std::vector<int>{ 1, 2 };
+        AssertThat(sb.view(), "n=42 v={ 1, 2 }");
+        AssertThat(rpp::format("%d-%s", 7, "x"), "7-x");
+    }
+
+#if RPP_HAS_COROUTINES
+    // an eager task runs to completion at construction, so this needs no event loop
+    static rpp::task<int> module_task() { co_return 99; }
+
+    TestCase(task_module_carries_the_whole_surface)
+    {
+        rpp::task<int> t = module_task();
+        AssertThat(t.valid(), true);
+        AssertThat(t.done(), true);
+        AssertThat(t.await_ready(), true);
+    }
+#endif
 };
 
 #endif // RPP_BUILD_WITH_MODULES

--- a/tests/test_modules_identity.cpp
+++ b/tests/test_modules_identity.cpp
@@ -1,14 +1,13 @@
 /**
- * Takes a trait address with no rpp header in this translation unit, so the address comes
+ * Takes a constant address with no rpp header in this translation unit, so the address comes
  * from the module alone. test_modules.cpp compares it against the header address.
  */
 #if RPP_BUILD_WITH_MODULES
-#include <vector>
 
-import rpp.type_traits; // includes come first, the import goes last
+import rpp.math; // includes come first, the import goes last
 
-// gcc gives a variable template without `inline` one copy per translation unit
-const void* module_is_container_addr() noexcept { return &rpp::is_container<std::vector<int>>; }
+// a namespace-scope constant without `inline` gets one copy per translation unit
+const void* module_pi_addr() noexcept { return &rpp::PI; }
 #else
-const void* module_is_container_addr() noexcept { return nullptr; }
+const void* module_pi_addr() noexcept { return nullptr; }
 #endif

--- a/tests/test_sanitizers.cpp
+++ b/tests/test_sanitizers.cpp
@@ -37,7 +37,7 @@ TestImpl(test_sanitizers)
     // A hidden or unexported symbol leaves every suppression dead. See BUGS.md C25.
     TestCase(tsan_suppression_hook_is_reachable)
     {
-    #if RPP_TSAN_BUILD && !_WIN32
+    #if RPP_TSAN_BUILD && !_WIN32 && defined(__GNUC__) && !defined(__clang__)
         // libtsan.so carries its own weak hook, so the address alone proves nothing
         using hook = const char* (*)();
         hook global = reinterpret_cast<hook>(dlsym(RTLD_DEFAULT, "__tsan_default_suppressions"));
@@ -45,6 +45,9 @@ TestImpl(test_sanitizers)
         const char* patterns = global();
         AssertNotEqual(patterns, nullptr);
         AssertNotEqual(strstr(patterns, "race:std::__future_base"), nullptr);
+    #elif RPP_TSAN_BUILD
+        // clang links its runtime statically, so the linker binds the hook and dlsym never sees it
+        AssertNotEqual(strstr(__tsan_default_suppressions(), "race:std::__future_base"), nullptr);
     #else
         AssertTrue(true); // only a TSAN build carries the hook
     #endif

--- a/tests/test_sanitizers.cpp
+++ b/tests/test_sanitizers.cpp
@@ -1,0 +1,52 @@
+#include <rpp/tests.h>
+
+// gcc defines __SANITIZE_THREAD__, and clang answers __has_feature instead
+#if defined(__SANITIZE_THREAD__)
+    #define RPP_TSAN_BUILD 1
+#elif defined(__has_feature)
+    #if __has_feature(thread_sanitizer)
+        #define RPP_TSAN_BUILD 1
+    #endif
+#endif
+
+#if RPP_TSAN_BUILD && !_WIN32
+#include <dlfcn.h> // dlsym, RTLD_DEFAULT
+#include <cstring> // strstr
+
+// TSAN cannot see the refcounts inside the uninstrumented standard library, so an object
+// freed after the last reader released looks like a race. See BUGS.md C25.
+extern "C" __attribute__((visibility("default"))) // -fvisibility=hidden hides it from libtsan.so
+const char* __tsan_default_suppressions() { // NOLINT(bugprone-reserved-identifier)
+    return "race:std::__1::promise\n"           // libc++ puts every promise in namespace __1
+           "race:std::__future_base\n"          // libstdc++ keeps the shared state here
+           "race:std::__exception_ptr\n"        // and the exception refcount here
+           "race:std::runtime_error::~runtime_error\n"
+           "race:std::range_error::~range_error\n"
+           // the report for this one names no library frame, so only the test scopes it
+           "race:test_future::test_except_handler_chaining\n";
+}
+#endif
+
+TestImpl(test_sanitizers)
+{
+    TestInit(test_sanitizers)
+    {
+    }
+
+    // gcc links libtsan.so, which reads the hook through the global dynamic symbol table.
+    // A hidden or unexported symbol leaves every suppression dead. See BUGS.md C25.
+    TestCase(tsan_suppression_hook_is_reachable)
+    {
+    #if RPP_TSAN_BUILD && !_WIN32
+        // libtsan.so carries its own weak hook, so the address alone proves nothing
+        using hook = const char* (*)();
+        hook global = reinterpret_cast<hook>(dlsym(RTLD_DEFAULT, "__tsan_default_suppressions"));
+        AssertNotEqual(global, nullptr);
+        const char* patterns = global();
+        AssertNotEqual(patterns, nullptr);
+        AssertNotEqual(strstr(patterns, "race:std::__future_base"), nullptr);
+    #else
+        AssertTrue(true); // only a TSAN build carries the hook
+    #endif
+    }
+};

--- a/tests/test_sprint.cpp
+++ b/tests/test_sprint.cpp
@@ -10,6 +10,13 @@
 #include <string> // std::string
 
 using namespace rpp;
+
+// rpp::has_to_string finds a free to_string through ADL only, so the probe needs its own namespace
+namespace adl_probe
+{
+    struct printable {};
+    inline std::string to_string(const printable&) noexcept { return "printable"; }
+}
 using namespace std::string_literals;
 
 struct external_to_string { };
@@ -78,6 +85,38 @@ TestImpl(test_sprint)
         static_assert(!rpp::has_std_to_string<scoped_enum>);
         static_assert(!rpp::has_std_to_string<std::string>);
         static_assert(!rpp::has_std_to_string<rpp::strview>);
+    }
+
+    // every trait below became a concept, and each one keeps the expression it detected before
+    TestCase(detection_traits_match_the_expressions_they_name)
+    {
+        struct has_all {
+            int size() const;
+            const char* begin() const;
+            const char* end() const;
+            std::string to_string() const;
+            int get() const;
+            void set(int);
+        };
+
+        static_assert(rpp::has_to_string_memb<has_all> && !rpp::has_to_string_memb<int>);
+        static_assert(rpp::has_get_memb<has_all> && !rpp::has_get_memb<int>);
+        static_assert(rpp::has_set_memb<has_all, int> && !rpp::has_set_memb<has_all, std::string>);
+        static_assert(rpp::is_iterable<has_all> && rpp::is_iterable<std::vector<int>>);
+        static_assert(!rpp::is_iterable<int>);
+        static_assert(rpp::is_stringlike<std::string> && !rpp::is_stringlike<std::vector<int>>);
+        static_assert(rpp::is_container<std::vector<int>> && rpp::is_container<has_all>);
+        static_assert(!rpp::is_container<std::string>); // string-like wins over container
+        static_assert(!rpp::is_container<int>);
+
+        // only ADL reaches the trait, because rpp::to_string is not declared where it is defined
+        static_assert(rpp::has_to_string<adl_probe::printable>);
+        static_assert(!rpp::has_to_string<int> && !rpp::has_to_string<std::string>);
+
+        // sprint dispatches the generic write() on these two
+        struct writes_itself { void operator<<(rpp::string_buffer&) const; };
+        static_assert(rpp::has_member_sbuf_op<writes_itself> && !rpp::has_member_sbuf_op<int>);
+        static_assert(rpp::has_ostream_op<int> && !rpp::has_ostream_op<writes_itself>);
     }
 
     TestCase(string_buf)

--- a/tests/test_sprint.cpp
+++ b/tests/test_sprint.cpp
@@ -62,6 +62,24 @@ TestImpl(test_sprint)
     {
     }
 
+    // the trait drives the write(const T&) fallback, and it became a concept for BUGS.md B8
+    TestCase(has_std_to_string_matches_what_std_to_string_takes)
+    {
+        struct converts_to_int { operator int() const { return 1; } };
+        struct converts_when_mutable { operator int() { return 1; } };
+        enum unscoped_enum { unscoped_value };
+        enum class scoped_enum { value };
+
+        static_assert(rpp::has_std_to_string<int>);
+        static_assert(rpp::has_std_to_string<double>);
+        static_assert(rpp::has_std_to_string<unscoped_enum>);
+        static_assert(rpp::has_std_to_string<converts_to_int>);
+        static_assert(rpp::has_std_to_string<converts_when_mutable>); // declval gives an rvalue
+        static_assert(!rpp::has_std_to_string<scoped_enum>);
+        static_assert(!rpp::has_std_to_string<std::string>);
+        static_assert(!rpp::has_std_to_string<rpp::strview>);
+    }
+
     TestCase(string_buf)
     {
         string_buffer buf; buf.writeln("str", 10, 20.1, "2132"_sv, "abcd"s);

--- a/tests/test_sprint.cpp
+++ b/tests/test_sprint.cpp
@@ -15,7 +15,7 @@ using namespace rpp;
 namespace adl_probe
 {
     struct printable {};
-    inline std::string to_string(const printable&) noexcept { return "printable"; }
+    inline std::string to_string(const printable& /*value*/) noexcept { return "printable"; }
 }
 using namespace std::string_literals;
 
@@ -74,7 +74,7 @@ TestImpl(test_sprint)
     {
         struct converts_to_int { operator int() const { return 1; } };
         struct converts_when_mutable { operator int() { return 1; } };
-        enum unscoped_enum { unscoped_value };
+        enum unscoped_enum : uint8_t { unscoped_value }; // it still promotes to int, so to_string takes it
         enum class scoped_enum : uint8_t { value };
 
         static_assert(rpp::has_std_to_string<int>);

--- a/tests/test_sprint.cpp
+++ b/tests/test_sprint.cpp
@@ -75,7 +75,7 @@ TestImpl(test_sprint)
         struct converts_to_int { operator int() const { return 1; } };
         struct converts_when_mutable { operator int() { return 1; } };
         enum unscoped_enum { unscoped_value };
-        enum class scoped_enum { value };
+        enum class scoped_enum : uint8_t { value };
 
         static_assert(rpp::has_std_to_string<int>);
         static_assert(rpp::has_std_to_string<double>);

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -54,6 +54,14 @@ def _skip(ns: str, kind: str, name: str) -> bool:
 # external linkage instead, which is what MSVC needs to define one in an importing TU
 INTERNAL_OK = frozenset()
 
+# a declaration a toolchain cannot carry across a module boundary. gcc-14 writes a .gcm no
+# importer can read when an export names a std::__cxx11 function, see BUGS.md B8
+NO_EXPORT = {'type_traits.h': frozenset({'has_std_to_string'})}
+
+# a re-export the same defect blocks. gcc-14 writes an unreadable .gcm when task.h sits in the
+# global module fragment and the module imports it back, see BUGS.md B8
+NO_IMPORT = {'task.h': frozenset({'rpp.future_types'})}
+
 
 CONFIG_MODULE = 'rpp.config'
 
@@ -102,11 +110,24 @@ def macro_collision(name: str) -> bool:
 def _exported(header: str, defines: tuple) -> dict:
     """Namespace to name to declaration line, for one macro configuration, in source order."""
     out = {}
+    blocked = NO_EXPORT.get(os.path.basename(header), frozenset())
     for ns, kind, name, internal, line in rd.declarations(header, defines):
-        if _skip(ns, kind, name): continue
+        if _skip(ns, kind, name) or name in blocked: continue
         if internal: continue  # clang rejects a using-declaration which exports one
         out.setdefault(ns, {}).setdefault(name, line)
     return out
+
+
+def _configuration(header: str, defines: tuple):
+    """The export map for one guard configuration, or None when the header rejects it.
+
+    sprint.h needs `std::to_string`, which bare metal drops, so the header does not compile
+    there at all. No guard per name saves a header a whole configuration rejects.
+    """
+    try:
+        return _exported(header, defines)
+    except RuntimeError:
+        return None
 
 
 def internal_names(header: str, allow: frozenset = None) -> list:
@@ -166,7 +187,7 @@ def _condition(ns: str, name: str, line: int, reduced: dict, spans: dict) -> str
 def export_block(header: str) -> str:
     """The generated block for one header, markers included."""
     base = _exported(header, BASE)
-    reduced = {g: _exported(header, BASE + off) for g, off in GUARDS}
+    reduced = {g: n for g, off in GUARDS if (n := _configuration(header, BASE + off)) is not None}
     spans = _guarded_spans(header)
     lines = [BEGIN]
 
@@ -179,6 +200,7 @@ def export_block(header: str) -> str:
         if inc == 'config.h': imports.add(CONFIG_MODULE)
         elif inc not in rd.NO_MODULE: imports.add(module_name(inc))
     imports.discard(module_name(header))
+    imports -= NO_IMPORT.get(os.path.basename(header), frozenset())
     lines += [f'export import {imp};' for imp in sorted(imports)]
 
     for ns in sorted(base):
@@ -244,6 +266,7 @@ def with_modules() -> list:
 
 _SELFTEST_HEADER = '''#pragma once
 #define RPP_HAS_COROUTINES 1                       // the real header derives this from __has_include
+#include "rpp/minmax.h"                            // an rpp include, so the block names rpp.minmax
 namespace rpp {
     constexpr double PI = 3.14159;                 // const at namespace scope, so internal
     static constexpr float radf(float d);          // static, so internal
@@ -297,6 +320,17 @@ def selftest() -> list:
         # the guarded member names its own class, and a text search would guard the class too
         if _condition('rpp', 'Unconditional', rpp_ns['Unconditional'], {}, spans):
             bad.append('a class a guarded member names took an #if')
+        # both defect workarounds drop something a working toolchain would carry
+        probe = os.path.basename(path)
+        if 'export import rpp.minmax;' not in export_block(path):
+            bad.append('an rpp include did not become an export import')
+        NO_EXPORT[probe], NO_IMPORT[probe] = frozenset({'Public'}), frozenset({'rpp.minmax'})
+        try:
+            block = export_block(path)
+            if 'using rpp::Public;' in block: bad.append('a NO_EXPORT name reached the export list')
+            if 'export import rpp.minmax;' in block: bad.append('a NO_IMPORT module reached the block')
+        finally:
+            del NO_EXPORT[probe], NO_IMPORT[probe]
     return bad
 
 

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -62,6 +62,10 @@ NO_EXPORT = {'type_traits.h': frozenset({'has_std_to_string'})}
 # global module fragment and the module imports it back, see BUGS.md B8
 NO_IMPORT = {'task.h': frozenset({'rpp.future_types'})}
 
+# a header which does not compile in a guard configuration, so no export list exists to reduce
+# against. Every other parse error is a real one, and the generator reports it
+NO_CONFIG = {'sprint.h': frozenset({'!RPP_BARE_METAL'})}
+
 
 CONFIG_MODULE = 'rpp.config'
 
@@ -118,16 +122,17 @@ def _exported(header: str, defines: tuple) -> dict:
     return out
 
 
-def _configuration(header: str, defines: tuple):
-    """The export map for one guard configuration, or None when the header rejects it.
+def _configuration(header: str, guard: str, defines: tuple):
+    """The export map for one guard configuration, or None when `NO_CONFIG` allows the failure.
 
-    sprint.h needs `std::to_string`, which bare metal drops, so the header does not compile
-    there at all. No guard per name saves a header a whole configuration rejects.
+    A header the allowlist names does not compile in that configuration, so no export list
+    exists to reduce against. Any other parse error reaches the caller and fails the run.
     """
     try:
         return _exported(header, defines)
     except RuntimeError:
-        return None
+        if guard in NO_CONFIG.get(os.path.basename(header), frozenset()): return None
+        raise
 
 
 def internal_names(header: str, allow: frozenset = None) -> list:
@@ -187,7 +192,7 @@ def _condition(ns: str, name: str, line: int, reduced: dict, spans: dict) -> str
 def export_block(header: str) -> str:
     """The generated block for one header, markers included."""
     base = _exported(header, BASE)
-    reduced = {g: n for g, off in GUARDS if (n := _configuration(header, BASE + off)) is not None}
+    reduced = {g: n for g, off in GUARDS if (n := _configuration(header, g, BASE + off)) is not None}
     spans = _guarded_spans(header)
     lines = [BEGIN]
 
@@ -331,6 +336,20 @@ def selftest() -> list:
             if 'export import rpp.minmax;' in block: bad.append('a NO_IMPORT module reached the block')
         finally:
             del NO_EXPORT[probe], NO_IMPORT[probe]
+        # a header the allowlist does not name must report its parse error, never drop the guard
+        broken = os.path.join(d, 'broken.h')
+        open(broken, 'w').write('#pragma once\n#if RPP_FREERTOS\n#error this header needs a host\n#endif\n')
+        try:
+            _configuration(broken, '!RPP_BARE_METAL', BASE + ('RPP_FREERTOS=1',))
+            bad.append('an unlisted parse failure returned instead of raising')
+        except RuntimeError:
+            pass
+        NO_CONFIG['broken.h'] = frozenset({'!RPP_BARE_METAL'})
+        try:
+            if _configuration(broken, '!RPP_BARE_METAL', BASE + ('RPP_FREERTOS=1',)) is not None:
+                bad.append('an allowlisted parse failure did not drop the guard')
+        finally:
+            del NO_CONFIG['broken.h']
     return bad
 
 


### PR DESCRIPTION
Three independent changes, plus the review round. Two close an open entry in `BUGS.md`, and one opens a new one.

## 1. B6: `libtsan.so` never read the suppression hook (`181035c`)

B6 blamed the libc++ spelling of the C15 pattern, and the cause is one attribute. gcc links
`libtsan.so`, which reads `__tsan_default_suppressions` through the global dynamic symbol
table. `-fvisibility=hidden` kept the definition out of it, so `dlsym` answered with the weak
hook inside `libtsan.so`, which returns null. Every pattern was dead since C15. clang links
its runtime statically, which is why C15 worked there.

The hook and its patterns moved to `tests/test_sanitizers.cpp`, beside a test which reads the
string back. On gcc it calls `dlsym(RTLD_DEFAULT, ...)`, and that call fails without the
attribute. clang takes the hook directly, because its static runtime never enters `.dynsym`.

Both reports on master name `test_future::test_except_handler_chaining`, which shares one
exception object between two pool workers. The refcount which orders them sits in an
uninstrumented `libstdc++.so`, so TSAN sees no edge and calls the free a race.

Measured on 2 pinned cores: 3 reports in 120 runs before, 0 in 120 after. Ten full-suite runs
matched no suppression at all, which is what B6 asked for.

One report survived the suppression, and it is a different defect. A pool worker reads its
semaphore after the pool destroyed it, so `BUGS.md` **B10** carries it.

## 2. B8: two shapes gcc-14 cannot write (`7b2db16`)

B8 said gcc-14 writes a module for `sprint.h` and `task.h` that no importer reads, and it
named a compiler defect with no shape. Both modules ship now. A bisect outside cmake, which
builds every `.cppm` into one `gcm.cache` and answers in seconds, found two shapes.

**Shape 1** reaches `rpp.sprint` through `rpp.type_traits`. An export which names a function
in the `std::__cxx11` inline namespace makes the module unreadable. `std::to_string` and
`std::stoi` both do it, and `std::swap` does not. The form does not matter. An `is_detected_v`
alias, a plain alias template and a C++20 concept all fail the same way, and so does a concept
which calls an unexported helper that names it. Only dropping the export works.

So the generator gains `NO_EXPORT`, and `has_std_to_string` leaves the module surface. A
header includer still gets the trait.

**Shape 2** reaches `rpp.task`. A module which includes `future_types.h` in its global module
fragment and also imports `rpp.future_types` writes an unreadable `.gcm`. Either half alone is
fine, and the importer only fails when it also includes `<rpp/tests.h>`. `NO_IMPORT` drops
that one re-export.

## 3. The detection idiom becomes C++20 concepts (`21920c4`)

ReCpp demands C++20, and `config.h` carries a `static_assert` which proves it. So every trait
built on `is_detected_v` became a concept, and every `enable_if_t` site became a `requires`
clause. `src/rpp` carries neither spelling now.

`type_traits.h` drops eight expression aliases and turns seven traits into concepts. Each one
keeps the expression it detected before, so `has_to_string` still reads through ADL alone, and
`is_container` still lets a string-like type lose to `is_stringlike`. `is_detected` and
`is_detected_v` stay, because a consumer brings its own alias, and krattlink does exactly that
in `MessageCodec.h`.

`sprint.h` had two detection aliases inside `string_buffer`, and a concept cannot live in a
class. Both moved to namespace scope as `has_ostream_op` and `has_member_sbuf_op`.
`mutex.h`, `binary_stream.h` and `sprint.h` took a `requires` clause each. `delegate.h` took
eight, and its two conditions read as named constants now.

`test_modules_identity.cpp` lost its anchor, because no variable template is left in
`type_traits.h`, so it takes the address of `rpp::PI` instead. That constant is one `math.h`
shipped without `inline`, which is the defect the case guards.

## 4. The review round, and a gate which was checking nothing (`b59eb6a`, `f039f52`, `04a55cc`, `c9497d9`)

Codex raised six findings. Five are fixed: the generator now re-raises a parse error the
`NO_CONFIG` allowlist does not name, C25 is two sentences, the plan counts read 18, the
module-only consumer includes `<utility>`, and B10 carries its own reproducer. The sixth asks
to remove the test-scoped TSAN pattern, and that thread stays open with the measurement,
because removing it reproduces B6 and no narrower pattern reaches the second report.

Two CI rounds went red on clang-tidy findings in the new test, and chasing them exposed
**B11**. `CXX20=1 mama gcc build clang-tidy test="nogdb -vv"`, which AGENTS.md names as the
gate, leaves `CMAKE_CXX_CLANG_TIDY` unset because mama reuses the directory a plain build
configured. It exits 0 having analyzed nothing. Adding `configure` sets the variable, and then
a gcc-14 build stops, because clang-tidy cannot parse the gcc module flags. The CI gcc-13 jobs
never hit that, because gcc-13 builds no modules.

## Verification

| Gate | Result |
|---|---|
| modules build, gcc-14 | 557/557 |
| header build, clang-18 | 534/534 |
| TSAN build, gcc-14 and clang-18 | 557/557 and 534/534 |
| module consumer, gcc | exits 0 on the modules path |
| the five generator and include gates | no finding |
| clang-tidy | see B11. The local gate analyzes nothing, so CI is the only real check. Each finding in this PR was verified against `clang-tidy-18` directly |

L2 is complete, so twenty-six modules ship. `docs/MODULES_MIGRATION.md` revision 10 carries
the handover state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJQak2qMQ4cXHtqEcpwimN