### PR TITLE
modules: the L4 layer, the &lt;string&gt; importer gate, and no more re-exports

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -83,8 +83,11 @@ grep -l 'heap-use-after-free' /tmp/b10_*.log
 ```
 
 ### B8. gcc-14 breaks a module for three shapes, and each one has a workaround
-`tools/gen_module_exports.py` carries `NO_EXPORT` with one entry and `NO_IMPORT` with three.
-Every module ships now. Delete an entry when a newer gcc reads the module back.
+`tools/gen_module_exports.py` carries `NO_EXPORT` with one entry. Every module ships now.
+Delete that entry when a newer gcc reads the module back.
+
+Shapes 2 and 3 both need a re-export, and `RE_EXPORT` holds one for the whole library, so
+neither can fire today. Read them before you add a second entry.
 
 `NO_CONFIG` is a third list, and it is not a gcc defect. It is empty, because `sprint.h`
 now guards its `std::to_string` branch the way `type_traits.h` guards the trait. Any parse
@@ -101,26 +104,25 @@ C++20 concept all fail the same way. So does a concept which calls an unexported
 names it. `NO_EXPORT` drops `has_std_to_string` from `rpp.type_traits`, which is what
 `rpp.sprint` imports. A header includer still gets the trait.
 
-Shape 2, in `rpp.task`, `rpp.tests` and `rpp.file_io`. A re-export makes the `.gcm`
-unreadable, and only an importer which included `<string>` first sees it. `import rpp.file_io`
-alone passes, and `#include <string>` before it fails. Each half of the module is innocent.
-Dropping every `export import` fixes it with the whole export list in place, and dropping
-every export fixes it with all four re-exports in place. `rpp.sprint` is the re-export which
-carries it, and `rpp.paths` re-exports `rpp.sprint` in turn, so `NO_IMPORT` drops both.
-`task.h` takes `rpp.future_types` for the same reason. An importer which needs
-`rpp::string_buffer`, `rpp::coro_handle` or the path functions imports that module itself.
+Shape 2 reached `rpp.task`, `rpp.tests` and `rpp.file_io` while every rpp include became a
+re-export. A re-export makes the `.gcm` unreadable, and only an importer which included
+`<string>` first sees it. `import rpp.file_io` alone passed, and `#include <string>` before
+it failed. Each half of the module was innocent. Dropping every `export import` fixed it
+with the whole export list in place, and dropping every export fixed it with all four
+re-exports in place. `rpp.sprint` was the re-export which carried it.
 
 `tests/module_consumer/std_string_module_only.cpp` is the gate. It includes `<string>` and
 then imports the six modules which name `std::string`, so this shape fails the build instead
-of a downstream consumer. Reverting the `file_io.h` entry makes that target report 2 errors.
+of a downstream consumer. Giving `file_io.h` its old re-exports makes that target report 2
+errors.
 
 Shape 3, in `rpp.tests`. gcc runs out of imported source locations and stops with
 `internal compiler error: in write_location, at cp/module.cc:16271`. It prints
 `unable to represent further imported source locations` first. The count is what matters,
 not one module. Seven re-exports pass, and `rpp.sprint` as the eighth crashes it, while
 `rpp.sprint` alone passes. The dependency `.gcm` files have to come from an `-O2` build to
-reach the limit, so a `-O0` bisect hides it. `NO_IMPORT` drops `rpp.sprint`, and an importer
-of `rpp.tests` which needs `rpp::string_buffer` imports `rpp.sprint` itself.
+reach the limit, so a `-O0` bisect hides it. `rpp.tests` re-exports one module now, so the
+count sits six below the crash.
 
 Reproduce either shape in seconds, outside cmake. Build every `.cppm` in the
 `RPP_MODULES_SRC` order into one `gcm.cache`, then compile a consumer:
@@ -130,7 +132,7 @@ for f in $(sed -n '/set(RPP_MODULES_SRC/,/^    )/p' ~/ReCpp/CMakeLists.txt | gre
   g++ -std=c++20 -fmodules-ts -I ~/ReCpp/src -c -x c++ ~/ReCpp/$f -o $(basename $f .cppm).o
 done
 printf '#include <rpp/tests.h>\nimport rpp.task;\nint main(){return 0;}\n' > u.cpp
-g++ -std=c++20 -fmodules-ts -I ~/ReCpp/src -c u.cpp -o u.o    # 0 errors with NO_IMPORT
+g++ -std=c++20 -fmodules-ts -I ~/ReCpp/src -c u.cpp -o u.o    # 0 errors under RE_EXPORT
 ```
 Put the offending line back into the generated block by hand to watch it fail. Only gcc 14.2
 ran this check, so retry on clang-21 and on a newer gcc.

--- a/BUGS.md
+++ b/BUGS.md
@@ -83,7 +83,7 @@ grep -l 'heap-use-after-free' /tmp/b10_*.log
 ```
 
 ### B8. gcc-14 breaks a module for three shapes, and each one has a workaround
-`tools/gen_module_exports.py` carries `NO_EXPORT` with one entry and `NO_IMPORT` with two.
+`tools/gen_module_exports.py` carries `NO_EXPORT` with one entry and `NO_IMPORT` with three.
 Every module ships now. Delete an entry when a newer gcc reads the module back.
 
 `NO_CONFIG` is a third list, and it is not a gcc defect. It is empty, because `sprint.h`
@@ -101,11 +101,18 @@ C++20 concept all fail the same way. So does a concept which calls an unexported
 names it. `NO_EXPORT` drops `has_std_to_string` from `rpp.type_traits`, which is what
 `rpp.sprint` imports. A header includer still gets the trait.
 
-Shape 2, in `rpp.task` and `rpp.tests`. A module which includes `future_types.h` in its
-global module fragment and also imports `rpp.future_types` writes an unreadable `.gcm`.
-Either half alone is fine. The importer only fails when it also includes `<rpp/tests.h>`.
-`NO_IMPORT` drops that one re-export, so an importer which needs `rpp::coro_handle` imports
-`rpp.future_types` itself.
+Shape 2, in `rpp.task`, `rpp.tests` and `rpp.file_io`. A re-export makes the `.gcm`
+unreadable, and only an importer which included `<string>` first sees it. `import rpp.file_io`
+alone passes, and `#include <string>` before it fails. Each half of the module is innocent.
+Dropping every `export import` fixes it with the whole export list in place, and dropping
+every export fixes it with all four re-exports in place. `rpp.sprint` is the re-export which
+carries it, and `rpp.paths` re-exports `rpp.sprint` in turn, so `NO_IMPORT` drops both.
+`task.h` takes `rpp.future_types` for the same reason. An importer which needs
+`rpp::string_buffer`, `rpp::coro_handle` or the path functions imports that module itself.
+
+`tests/module_consumer/std_string_module_only.cpp` is the gate. It includes `<string>` and
+then imports the six modules which name `std::string`, so this shape fails the build instead
+of a downstream consumer. Reverting the `file_io.h` entry makes that target report 2 errors.
 
 Shape 3, in `rpp.tests`. gcc runs out of imported source locations and stops with
 `internal compiler error: in write_location, at cp/module.cc:16271`. It prints

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,12 @@ if(RPP_BUILD_MODULES)
         src/rpp/rpp-mutex.cppm
         src/rpp/rpp-paths.cppm
         src/rpp/rpp-tests.cppm
+        # L4
+        src/rpp/rpp-atomic_shared_ptr.cppm
+        src/rpp/rpp-close_sync.cppm
+        src/rpp/rpp-condition_variable.cppm
+        src/rpp/rpp-file_io.cppm
+        src/rpp/rpp-sockets.cppm
     )
 
     # Add module interface to the library target

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ preprocessed lines and needs no split.
 
 ### Available modules
 
-Thirty-one modules ship. `src/rpp/rpp-*.cppm` names each one, and section 9 of
+Thirty-six modules ship. `src/rpp/rpp-*.cppm` names each one, and section 9 of
 [`docs/MODULES_MIGRATION.md`](docs/MODULES_MIGRATION.md) lists them by dependency layer,
 with the ones still to come. Each `.cppm` carries the export list its header earned, so read
 that file for the names a module gives you.
@@ -189,9 +189,10 @@ export using ::LogSeverityWarn;   // an unscoped enum does not carry its enumera
 ```
 
 `BUILD_WITH_MODULES=ON` puts the module file set on `RppTests` and builds
-`tests/test_modules.cpp`, which imports every module. `tests/module_consumer/` adds five
-module-only targets. Each of those imports one module and includes no rpp header except a
-macro header, so a missing export fails the build.
+`tests/test_modules.cpp`, which imports every module. `tests/module_consumer/` adds six
+module-only targets. Five import one module each and include no rpp header except a macro
+header, so a missing export fails the build. The sixth includes `<string>` first, because
+gcc-14 writes a module that only such an importer cannot read. See `BUGS.md` B8.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ compile errors.
 import rpp.strview;      // 3. imports, last
 ```
 
+**A module re-exports nothing.** `sprint.h` includes `strview.h`, and
+`import rpp.sprint;` still leaves `rpp::strview` invisible. Name that module too. A
+header leaks whatever its includes pull in, and a module hands over only what the
+importer asked for. `rpp.tests` is the one exception, and it re-exports
+`rpp.strview` for the `TestImpl` constructor.
+
 ### Macros need a header
 
 A C++20 module cannot export a macro. Where the macro surface is worth splitting, the
@@ -190,9 +196,10 @@ export using ::LogSeverityWarn;   // an unscoped enum does not carry its enumera
 
 `BUILD_WITH_MODULES=ON` puts the module file set on `RppTests` and builds
 `tests/test_modules.cpp`, which imports every module. `tests/module_consumer/` adds six
-module-only targets. Five import one module each and include no rpp header except a macro
-header, so a missing export fails the build. The sixth includes `<string>` first, because
-gcc-14 writes a module that only such an importer cannot read. See `BUGS.md` B8.
+module-only targets. Each one imports what it needs and includes no rpp header except a
+macro header, so a missing export fails the build. `RppStdStringModuleOnly` includes
+`<string>` first, because gcc-14 writes a module that only such an importer cannot read.
+See `BUGS.md` B8.
 
 ---
 

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -1,6 +1,6 @@
 # ReCpp C++20 Modules Migration Plan
 
-Revision 12. Thirty-six modules exist: all of L0 to L4.
+Revision 13. Thirty-six modules exist: all of L0 to L4. Only `rpp.tests` re-exports another.
 
 This document explains the pattern, records what real builds prove about it, and
 gives the phased plan for the remaining 8 headers.
@@ -29,11 +29,12 @@ gate, #65 changeset 6.
 
 **Next:** changeset 5, the L5 layer. Section 9 has the layers.
 
-**Four modules ship with a workaround: `rpp.sprint`, `rpp.task`, `rpp.tests` and
-`rpp.file_io`.** The generator carries `NO_EXPORT` with one entry and `NO_IMPORT` with three,
-and `BUGS.md` **B8** names the three shapes gcc-14 breaks. `NO_CONFIG` is empty, because
-`sprint.h` now guards its `std::to_string` branch the way `type_traits.h` guards the trait.
-The generator selftest still pins all three knobs.
+**A module re-exports nothing, and `rpp.sprint` ships with a workaround.** The generator
+carries `NO_EXPORT` with one entry and `RE_EXPORT` with one, and `BUGS.md` **B8** names the
+three shapes gcc-14 breaks. Shapes 2 and 3 both need a re-export, so neither can fire on one
+library-wide entry. `NO_CONFIG` is empty, because `sprint.h` now guards its `std::to_string`
+branch the way `type_traits.h` guards the trait. The generator selftest still pins all three
+knobs.
 
 **An importer which includes `<string>` first reads a different module.** `rpp.file_io`
 passed every gate and still broke that consumer, so `std_string_module_only.cpp` holds the
@@ -45,8 +46,8 @@ unexported helper all fail the same way. The export reaches a `std::__cxx11` fun
 way. Only dropping the export works, so `has_std_to_string` left the module surface.
 The concept stayed, because it reads better and skips one `is_detected_v` instantiation.
 
-Delete a `NO_EXPORT` or `NO_IMPORT` entry when a newer gcc reads the module back. The B8
-reproducer builds every `.cppm` into one `gcm.cache` outside cmake, which answers in seconds.
+Delete the `NO_EXPORT` entry when a newer gcc reads the module back. The B8 reproducer builds
+every `.cppm` into one `gcm.cache` outside cmake, which answers in seconds.
 
 **What L1 and L2 exposed.** Six headers declared public API the compiler could not export,
 and each fix landed with the layer. `math.h` marked every function `static` and left its
@@ -302,15 +303,20 @@ ReCpp's own `.cpp` files keep using headers. The module facade exists for
 consumers, not for the library's own build. This mirrors libstdc++, whose own
 sources do not `import std`.
 
-### D5. Each module re-exports its header's rpp dependencies.
+### D5. A module re-exports nothing, and an importer names every module it uses.
 
-`sprint.h` includes `strview.h`, so `rpp.sprint` must give the importer
-`rpp::strview`. Otherwise `import rpp.sprint;` returns a `string_buffer` the
-caller cannot feed a `strview` into. Findings 5 and 6 confirm both directions.
+A header leaks whatever its includes pull in. A module owes an importer no such
+leak, so `RE_EXPORT` starts empty and a surface has to earn its entry.
 
-The rule: **for every `#include "X.h"` in `Y.h`, `rpp-Y.cppm` gets one
-`export import rpp.X;`.** The module graph then matches the include graph, and a
-script can check it. Changeset 2 is what makes that include graph honest.
+The first rule was the opposite one. Every `#include "X.h"` in `Y.h` gave
+`rpp-Y.cppm` an `export import rpp.X;`, so the module graph mirrored the include
+graph. That put 61 re-export lines in the library. With all 61 gone, the 571 case
+suite stayed green and five of the six module consumers passed.
+`RppTestsModuleOnly` was the sixth, and one line fixed it. `TestImpl` expands to a
+constructor which takes `rpp::strview`, so `rpp.tests` re-exports `rpp.strview`.
+
+A consumer which needs `rpp::strview` from `import rpp.sprint;` writes
+`import rpp.strview;` too. One line names what that consumer depends on.
 
 ### D6. Ship `.cppm` sources. Never ship a binary module interface.
 
@@ -380,9 +386,10 @@ distro-packaged clang does not need this.
 MSVC is tier 1. A local build on MSVC 14.44 compiles both modules. It exposed one
 rule the other compilers hide: **the same `.cppm` must not reach two targets that
 also link each other.** MSVC then finds two IFCs for one module name and fails with
-`C7684 module name 'rpp.strview' has an ambiguous resolution to IFC`. The
-module-only consumer checks live inside `RppTests` for that reason, not in a target
-of their own.
+`C7684 module name 'rpp.strview' has an ambiguous resolution to IFC`.
+`tests/test_modules.cpp` lives inside `RppTests` for that reason, not in a second
+in-tree target. `tests/module_consumer/` is a separate project which links the
+installed library, so each of its targets compiles the `.cppm` files once.
 
 ---
 
@@ -486,16 +493,16 @@ one-line note in the release text saves each team the bisect.
 The std half of this check went with changeset 1a. The rpp half is load-bearing
 for modules, and for a different reason.
 
-D5 gives each module one `export import rpp.X;` per rpp include, and changeset 3
-generates those lines from the include list. Finding 6 measured what a missing one
+D5 first gave each module one `export import rpp.X;` per rpp include, and changeset
+3 generated those lines from the include list. Finding 6 measured what a missing one
 costs: the consumer fails with
 `error: missing '#include'; 'strview' must be declared before it is used`.
 **Reachable is not visible for an rpp name, even though it is for a std name.**
 
-A header that names `rpp::strview` and does not include `strview.h` yields a
-`.cppm` with a missing `export import`. Every importer of it then breaks. Add this
-check before changeset 3 generates anything from the include graph. It also turns
-the 43 redundant findings into an exact list of the includes to add.
+D5 dropped that rule later, and the check still earns its place. The global module
+fragment of a `.cppm` includes one header, so a header which names `rpp::strview`
+and skips `strview.h` breaks its own module. The check also turns the 43 redundant
+findings into an exact list of the includes to add.
 
 **Estimate: half a day.**
 
@@ -577,7 +584,7 @@ the macro header stays free of includes.
 | Header | Module? | Split macros? | Why |
 |---|---|---|---|
 | `log_colors.h` | no | no | 114 macros, 0 declarations. Rule 1. |
-| `config.h` | **no** | **the types split out** | Rule 1 for the macros. The integer aliases moved to `config.types.h`, which module `rpp.config` exports. `config.h` includes `config.types.h`, so header-mode consumers keep the aliases, and a module writes one `export import rpp.config` rather than re-listing ten. `rpp.strview`, `rpp.debugging` and `rpp.config` prove the pattern. |
+| `config.h` | **no** | **the types split out** | Rule 1 for the macros. The integer aliases moved to `config.types.h`, which module `rpp.config` exports. `config.h` includes `config.types.h`, so header-mode consumers keep the aliases, and a module consumer writes one `import rpp.config` rather than re-listing ten. `rpp.strview`, `rpp.debugging` and `rpp.config` prove the pattern. |
 | `config.types.h` | **yes, `rpp.config`** | n/a | The ten integer aliases, split from `config.h` so a module can export them. A macro cannot be exported, so the macros stay in `config.h`. |
 | `debugging.h` | yes | **yes, and it pays** | The split is done and measured. `debugging.macros.h` costs 50 preprocessed lines, `debugging.h` costs 32893. Section 6.4 has the numbers. |
 | `endian.h` | yes | **no** | The 9 byte-swap macros would split cleanly into compiler builtins, but 9 macros do not pay for a new header and a new name to remember. |
@@ -711,8 +718,8 @@ The tool, as built:
    underscore stays, because `_LogInfo` and `_FmtString` are part of that surface.
    It also drops an internal-linkage name, because clang rejects a using-declaration
    which exports a `static` function. gcc accepts one, so only clang-21 caught it.
-4. Reads the include list of the header and emits one `export import rpp.X;` per
-   rpp include (D5).
+4. Emits an `export import rpp.X;` only where `RE_EXPORT` names one, because a
+   module re-exports nothing by default (D5).
 5. Writes the `.cppm` between two marker comments, so hand-written parts survive.
 6. `--check` mode re-generates into memory and diffs. A difference fails CI.
 7. Reports a module whose name repeats a macro any rpp header defines, and `STEMS` holds
@@ -785,8 +792,9 @@ Two smaller notes for whoever writes more of these tests:
 ## 9. Changeset 5: write the modules, in dependency layers
 
 Work the include graph bottom up. A module can only build after every module it
-`export import`s exists. The layers below come from the actual `#include` graph
-of `src/rpp/*.h`, so changeset 1b can move a header between layers.
+imports exists, and its export list follows its header. The layers below come from
+the actual `#include` graph of `src/rpp/*.h`, so changeset 1b can move a header
+between layers.
 
 | Layer | Modules | Count |
 |---|---|---|

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -1,9 +1,9 @@
 # ReCpp C++20 Modules Migration Plan
 
-Revision 11. Thirty-one modules exist: all of L0, L1, L2 and L3.
+Revision 12. Thirty-six modules exist: all of L0 to L4.
 
 This document explains the pattern, records what real builds prove about it, and
-gives the phased plan for the remaining 13 headers.
+gives the phased plan for the remaining 8 headers.
 
 ## Handover state
 
@@ -12,28 +12,32 @@ gate, #65 changeset 6.
 
 | Item | State |
 |---|---|
-| the thirty-one modules | build and pass on gcc-14, and CI covers clang-21 and MSVC 14.52 |
+| the thirty-six modules | build and pass on gcc-14, and CI covers clang-21 and MSVC 14.52 |
 | `debugging.macros.h` | split out, 50 preprocessed lines against 32893 |
 | `BUILD_WITH_MODULES=AUTO` | on per toolchain, GCC 14 / Clang 21 / MSVC 19.34 |
 | Include-order style rule | in AGENTS.md, and the `import-order` gate holds it |
 | `tools/check_includes.py` | 6 checks. 4 gate CI, and `missing` and `unused` stay ungated |
-| `tests/test_modules.cpp` | module consumer test, 28 cases. It includes `tests.h` and the macro header only, so what those two mask needs a module-only target |
-| `tests/module_consumer/` | a real mama consumer, on gcc, clang and MSVC, with 5 module-only targets |
+| `tests/test_modules.cpp` | module consumer test, 33 cases. It includes `tests.h` and the macro header only, so what those two mask needs a module-only target |
+| `tests/module_consumer/` | a real mama consumer, on gcc, clang and MSVC, with 6 module-only targets |
 | mama | 0.14.0 exports the `.cppm` files and strips the module objects |
 | CI | 28 jobs on GitHub Actions, and CircleCI is gone |
-| test counts | 566/566 on the modules build, 538/538 on the header build |
+| test counts | 571/571 on the modules build, 538/538 on the header build |
 
 **Changeset state:** 1a is dropped, see section 4. 1b, 2, 3 and the mama half of
-6 landed. The generator drives all thirty-one modules. 4 is done through the generator
-`--check`. 5 has L0 to L3 finished. Section 11 lists what 7 owes.
+6 landed. The generator drives all thirty-six modules. 4 is done through the generator
+`--check`. 5 has L0 to L4 finished. Section 11 lists what 7 owes.
 
-**Next:** changeset 5, the L4 layer. Section 9 has the layers.
+**Next:** changeset 5, the L5 layer. Section 9 has the layers.
 
-**`rpp.sprint`, `rpp.task` and `rpp.tests` ship, and each cost a workaround.** The generator
-carries `NO_EXPORT` with one entry and `NO_IMPORT` with two, and `BUGS.md` **B8** names the
-three shapes gcc-14 breaks. `NO_CONFIG` is empty, because `sprint.h` now guards its
-`std::to_string` branch the way `type_traits.h` guards the trait. The generator selftest
-still pins all three knobs.
+**Four modules ship with a workaround: `rpp.sprint`, `rpp.task`, `rpp.tests` and
+`rpp.file_io`.** The generator carries `NO_EXPORT` with one entry and `NO_IMPORT` with three,
+and `BUGS.md` **B8** names the three shapes gcc-14 breaks. `NO_CONFIG` is empty, because
+`sprint.h` now guards its `std::to_string` branch the way `type_traits.h` guards the trait.
+The generator selftest still pins all three knobs.
+
+**An importer which includes `<string>` first reads a different module.** `rpp.file_io`
+passed every gate and still broke that consumer, so `std_string_module_only.cpp` holds the
+shape now. Add a module which names `std::string` to that target when it lands.
 
 An `is_detected_v` alias which names `std::to_string` was the first shape, so the C++20
 concept replaced it. That did not help. A plain alias, a concept, and a concept which calls an
@@ -790,16 +794,16 @@ of `src/rpp/*.h`, so changeset 1b can move a header between layers.
 | L1 | **bitutils** ✓, **debugging** ✓, **delegate** ✓, **endian** ✓, **future_types** ✓, **math** ✓, **predicates** ✓, **proc_utils** ✓, **sort** ✓, **source_loc** ✓, **strview** ✓, **timepoint** ✓, **traits** ✓, **type_traits** ✓ | 14 |
 | L2 | **atomic_timepoint** ✓, **collections** ✓, **sprint** ✓, **stack_trace** ✓, **task** ✓, **threads** ✓, **timer** ✓, **vec** ✓ | 8 |
 | L3 | **load_balancer** ✓, **memory_pool** ✓, **mutex** ✓, **paths** ✓, **tests** ✓ | 5 |
-| L4 | atomic_shared_ptr, close_sync, condition_variable, file_io, sockets | 5 |
+| L4 | **atomic_shared_ptr** ✓, **close_sync** ✓, **condition_variable** ✓, **file_io** ✓, **sockets** ✓ | 5 |
 | L5 | binary_stream, concurrent_queue, semaphore | 3 |
 | L6 | binary_serializer, thread_pool | 2 |
 | L7 | event_loop, future | 2 |
 | L8 | coroutines | 1 |
 | top | umbrella `rpp` | 1 |
 
-Every L3 module ships. `BUILD_WITH_MODULES` builds all thirty-one.
+Every L4 module ships. `BUILD_WITH_MODULES` builds all thirty-six.
 
-44 modules and one umbrella. L0 to L3 exist, so 13 remain. Excluded: `config.h`
+44 modules and one umbrella. L0 to L4 exist, so 8 remain. Excluded: `config.h`
 and `log_colors.h` by rule 1 of section 6.3, and `jni_cpp.h` because it is
 Android glue. `tests.h` is in, and it is the one header whose macros split into
 `tests.macros.h`.

--- a/src/rpp/rpp-atomic_shared_ptr.cppm
+++ b/src/rpp/rpp-atomic_shared_ptr.cppm
@@ -7,7 +7,6 @@ module;
 export module rpp.atomic_shared_ptr;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.mutex;
 
 export namespace rpp {
     using rpp::atomic_shared_ptr;

--- a/src/rpp/rpp-atomic_shared_ptr.cppm
+++ b/src/rpp/rpp-atomic_shared_ptr.cppm
@@ -1,0 +1,16 @@
+// C++20 module interface unit for <rpp/atomic_shared_ptr.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "atomic_shared_ptr.h"
+
+export module rpp.atomic_shared_ptr;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.mutex;
+
+export namespace rpp {
+    using rpp::atomic_shared_ptr;
+    using rpp::atomic_weak_ptr;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-atomic_timepoint.cppm
+++ b/src/rpp/rpp-atomic_timepoint.cppm
@@ -7,8 +7,6 @@ module;
 export module rpp.atomic_timepoint;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
-export import rpp.timepoint;
 
 export namespace rpp {
     using rpp::AtomicDuration;

--- a/src/rpp/rpp-close_sync.cppm
+++ b/src/rpp/rpp-close_sync.cppm
@@ -1,0 +1,18 @@
+// C++20 module interface unit for <rpp/close_sync.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "close_sync.h"
+
+export module rpp.close_sync;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.debugging;
+export import rpp.mutex;
+
+export namespace rpp {
+    using rpp::readonly_lock;
+    using rpp::exclusive_lock;
+    using rpp::close_sync;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-close_sync.cppm
+++ b/src/rpp/rpp-close_sync.cppm
@@ -7,8 +7,6 @@ module;
 export module rpp.close_sync;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.debugging;
-export import rpp.mutex;
 
 export namespace rpp {
     using rpp::readonly_lock;

--- a/src/rpp/rpp-collections.cppm
+++ b/src/rpp/rpp-collections.cppm
@@ -7,7 +7,6 @@ module;
 export module rpp.collections;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.sort;
 
 export namespace rpp {
     using rpp::element_range;

--- a/src/rpp/rpp-condition_variable.cppm
+++ b/src/rpp/rpp-condition_variable.cppm
@@ -7,12 +7,6 @@ module;
 export module rpp.condition_variable;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
-export import rpp.debugging;
-export import rpp.mutex;
-export import rpp.predicates;
-export import rpp.timepoint;
-export import rpp.timer;
 
 export namespace rpp {
     using rpp::_cv_remaining_duration;

--- a/src/rpp/rpp-condition_variable.cppm
+++ b/src/rpp/rpp-condition_variable.cppm
@@ -1,0 +1,21 @@
+// C++20 module interface unit for <rpp/condition_variable.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "condition_variable.h"
+
+export module rpp.condition_variable;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+export import rpp.debugging;
+export import rpp.mutex;
+export import rpp.predicates;
+export import rpp.timepoint;
+export import rpp.timer;
+
+export namespace rpp {
+    using rpp::_cv_remaining_duration;
+    using rpp::condition_variable;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-debugging.cppm
+++ b/src/rpp/rpp-debugging.cppm
@@ -9,7 +9,6 @@ module;
 export module rpp.debugging;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
 
 export using ::LogSeverity;
 export using ::LogSeverityInfo;

--- a/src/rpp/rpp-delegate.cppm
+++ b/src/rpp/rpp-delegate.cppm
@@ -7,7 +7,6 @@ module;
 export module rpp.delegate;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
 
 export namespace rpp {
     using rpp::delegate;

--- a/src/rpp/rpp-endian.cppm
+++ b/src/rpp/rpp-endian.cppm
@@ -7,7 +7,6 @@ module;
 export module rpp.endian;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
 
 export namespace rpp {
     using rpp::writeBEU16;

--- a/src/rpp/rpp-file_io.cppm
+++ b/src/rpp/rpp-file_io.cppm
@@ -1,0 +1,21 @@
+// C++20 module interface unit for <rpp/file_io.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "file_io.h"
+
+export module rpp.file_io;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+export import rpp.strview;
+
+export namespace rpp {
+    using rpp::load_buffer;
+    using rpp::file;
+    using rpp::buffer_parser;
+    using rpp::buffer_line_parser;
+    using rpp::buffer_bracket_parser;
+    using rpp::buffer_keyval_parser;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-file_io.cppm
+++ b/src/rpp/rpp-file_io.cppm
@@ -7,8 +7,6 @@ module;
 export module rpp.file_io;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
-export import rpp.strview;
 
 export namespace rpp {
     using rpp::load_buffer;

--- a/src/rpp/rpp-future_types.cppm
+++ b/src/rpp/rpp-future_types.cppm
@@ -7,7 +7,6 @@ module;
 export module rpp.future_types;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
 
 export namespace rpp {
     using rpp::cfuture;

--- a/src/rpp/rpp-load_balancer.cppm
+++ b/src/rpp/rpp-load_balancer.cppm
@@ -7,9 +7,6 @@ module;
 export module rpp.load_balancer;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
-export import rpp.timepoint;
-export import rpp.timer;
 
 export namespace rpp {
     using rpp::load_balancer;

--- a/src/rpp/rpp-math.cppm
+++ b/src/rpp/rpp-math.cppm
@@ -7,7 +7,6 @@ module;
 export module rpp.math;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.minmax;
 
 export namespace rpp {
     using rpp::PI;

--- a/src/rpp/rpp-memory_pool.cppm
+++ b/src/rpp/rpp-memory_pool.cppm
@@ -7,8 +7,6 @@ module;
 export module rpp.memory_pool;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.collections;
-export import rpp.config;
 
 export namespace rpp {
     using rpp::pool_types_constructor;

--- a/src/rpp/rpp-mutex.cppm
+++ b/src/rpp/rpp-mutex.cppm
@@ -7,11 +7,6 @@ module;
 export module rpp.mutex;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
-export import rpp.threads;
-export import rpp.timepoint;
-export import rpp.timer;
-export import rpp.type_traits;
 
 export namespace rpp {
     using rpp::mutex;

--- a/src/rpp/rpp-paths.cppm
+++ b/src/rpp/rpp-paths.cppm
@@ -7,9 +7,6 @@ module;
 export module rpp.paths;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
-export import rpp.sprint;
-export import rpp.strview;
 
 export namespace rpp {
     using rpp::file_exists;

--- a/src/rpp/rpp-predicates.cppm
+++ b/src/rpp/rpp-predicates.cppm
@@ -7,7 +7,6 @@ module;
 export module rpp.predicates;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
 
 export namespace rpp {
     using rpp::IsCallable;

--- a/src/rpp/rpp-proc_utils.cppm
+++ b/src/rpp/rpp-proc_utils.cppm
@@ -7,7 +7,6 @@ module;
 export module rpp.proc_utils;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
 
 export namespace rpp {
     using rpp::proc_mem_info;

--- a/src/rpp/rpp-sockets.cppm
+++ b/src/rpp/rpp-sockets.cppm
@@ -7,10 +7,6 @@ module;
 export module rpp.sockets;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
-export import rpp.load_balancer;
-export import rpp.mutex;
-export import rpp.strview;
 
 export namespace rpp {
     using rpp::address_family;

--- a/src/rpp/rpp-sockets.cppm
+++ b/src/rpp/rpp-sockets.cppm
@@ -1,0 +1,68 @@
+// C++20 module interface unit for <rpp/sockets.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "sockets.h"
+
+export module rpp.sockets;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+export import rpp.config;
+export import rpp.load_balancer;
+export import rpp.mutex;
+export import rpp.strview;
+
+export namespace rpp {
+    using rpp::address_family;
+    using rpp::AF_DontCare;
+    using rpp::AF_IPv4;
+    using rpp::AF_IPv6;
+    using rpp::AF_Bth;
+    using rpp::socket_type;
+    using rpp::ST_Unspecified;
+    using rpp::ST_Stream;
+    using rpp::ST_Datagram;
+    using rpp::ST_Raw;
+    using rpp::ST_RDM;
+    using rpp::ST_SeqPacket;
+    using rpp::socket_category;
+    using rpp::SC_Unknown;
+    using rpp::SC_Listen;
+    using rpp::SC_Accept;
+    using rpp::SC_Client;
+    using rpp::ip_protocol;
+    using rpp::IPP_DontCare;
+    using rpp::IPP_ICMP;
+    using rpp::IPP_IGMP;
+    using rpp::IPP_BTH;
+    using rpp::IPP_TCP;
+    using rpp::IPP_UDP;
+    using rpp::IPP_ICMPV6;
+    using rpp::IPP_PGM;
+    using rpp::socket_option;
+    using rpp::SO_None;
+    using rpp::SO_ReuseAddr;
+    using rpp::SO_Blocking;
+    using rpp::SO_NonBlock;
+    using rpp::SO_Nagle;
+    using rpp::to_addrfamily;
+    using rpp::to_socktype;
+    using rpp::to_ipproto;
+    using rpp::addrfamily_int;
+    using rpp::socktype_int;
+    using rpp::ipproto_int;
+    using rpp::protocol_info;
+    using rpp::raw_address;
+    using rpp::ipaddress;
+    using rpp::ipaddress4;
+    using rpp::ipaddress6;
+    using rpp::ipinterface;
+    using rpp::socket;
+    using rpp::make_udp_randomport;
+    using rpp::make_tcp_randomport;
+    using rpp::get_ip_interface;
+    using rpp::get_system_ip;
+    using rpp::get_broadcast_ip;
+    using rpp::get_network_handle;
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-sort.cppm
+++ b/src/rpp/rpp-sort.cppm
@@ -7,7 +7,6 @@ module;
 export module rpp.sort;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
 
 export namespace rpp {
     using rpp::sort_comparison;

--- a/src/rpp/rpp-source_loc.cppm
+++ b/src/rpp/rpp-source_loc.cppm
@@ -7,7 +7,6 @@ module;
 export module rpp.source_loc;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
 
 export namespace rpp {
     using rpp::source_loc;

--- a/src/rpp/rpp-sprint.cppm
+++ b/src/rpp/rpp-sprint.cppm
@@ -2,10 +2,6 @@ module;
 #include "sprint.h"
 export module rpp.sprint;
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
-export import rpp.debugging;
-export import rpp.strview;
-export import rpp.type_traits;
 
 export namespace rpp {
     using rpp::to_string;

--- a/src/rpp/rpp-stack_trace.cppm
+++ b/src/rpp/rpp-stack_trace.cppm
@@ -7,8 +7,6 @@ module;
 export module rpp.stack_trace;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
-export import rpp.strview;
 
 export namespace rpp {
     using rpp::CallstackEntry;

--- a/src/rpp/rpp-strview.cppm
+++ b/src/rpp/rpp-strview.cppm
@@ -8,7 +8,6 @@ module;
 export module rpp.strview;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
 
 export namespace rpp {
     using rpp::strcontains;

--- a/src/rpp/rpp-tests.cppm
+++ b/src/rpp/rpp-tests.cppm
@@ -9,11 +9,6 @@ module;
 export module rpp.tests;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
-export import rpp.debugging;
-export import rpp.math;
-export import rpp.minmax;
-export import rpp.source_loc;
 export import rpp.strview;
 
 export namespace rpp {

--- a/src/rpp/rpp-threads.cppm
+++ b/src/rpp/rpp-threads.cppm
@@ -7,8 +7,6 @@ module;
 export module rpp.threads;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
-export import rpp.strview;
 
 export namespace rpp {
     using rpp::yield;

--- a/src/rpp/rpp-timepoint.cppm
+++ b/src/rpp/rpp-timepoint.cppm
@@ -7,7 +7,6 @@ module;
 export module rpp.timepoint;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
 
 export using ::time_now_seconds;
 

--- a/src/rpp/rpp-timer.cppm
+++ b/src/rpp/rpp-timer.cppm
@@ -7,8 +7,6 @@ module;
 export module rpp.timer;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
-export import rpp.timepoint;
 
 export namespace rpp {
     using rpp::Timer;

--- a/src/rpp/rpp-type_traits.cppm
+++ b/src/rpp/rpp-type_traits.cppm
@@ -7,7 +7,6 @@ module;
 export module rpp.type_traits;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.config;
 
 export namespace rpp {
     using rpp::is_detected;

--- a/src/rpp/rpp-vec.cppm
+++ b/src/rpp/rpp-vec.cppm
@@ -7,8 +7,6 @@ module;
 export module rpp.vec;
 
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
-export import rpp.math;
-export import rpp.strview;
 
 export namespace rpp {
     using rpp::Vector2;

--- a/tests/module_consumer/CMakeLists.txt
+++ b/tests/module_consumer/CMakeLists.txt
@@ -36,6 +36,12 @@ add_executable(RppSortModuleOnly sort_module_only.cpp)
 target_include_directories(RppSortModuleOnly PRIVATE ${MAMA_INCLUDES})
 mama_target_modules(RppSortModuleOnly)
 
+# gcc-14 breaks a module whose importer included <string> first, so this target holds that shape
+add_executable(RppStdStringModuleOnly std_string_module_only.cpp)
+target_include_directories(RppStdStringModuleOnly PRIVATE ${MAMA_INCLUDES})
+mama_target_modules(RppStdStringModuleOnly)
+target_link_libraries(RppStdStringModuleOnly PRIVATE ${MAMA_LIBS})
+
 # the tests.h macro split only pays when tests.macros.h plus rpp.tests writes a suite
 add_executable(RppTestsModuleOnly tests_module_only.cpp)
 target_include_directories(RppTestsModuleOnly PRIVATE ${MAMA_INCLUDES})

--- a/tests/module_consumer/std_string_module_only.cpp
+++ b/tests/module_consumer/std_string_module_only.cpp
@@ -1,0 +1,25 @@
+// Includes <string> before importing every module which names std::string on its surface.
+// gcc-14 writes a .gcm no such importer can read for some of them, so this target is the gate.
+// test_modules.cpp cannot catch it, because it imports every module at once. See BUGS.md B8.
+#ifdef MAMA_HAS_MODULES
+#include <string> // the include which makes gcc reconcile std::__cxx11 against the module
+
+import rpp.strview; // includes come first, the imports go last
+import rpp.sprint;
+import rpp.paths;
+import rpp.file_io;
+import rpp.sockets;
+import rpp.tests;
+
+int main()
+{
+    std::string s = rpp::to_string(42);
+    bool ok = s == "42"
+           && rpp::file_ext("a/b.txt") == "txt"
+           && rpp::ipaddress{"127.0.0.1:80"}.port() == 80
+           && rpp::file{"this_file_does_not_exist"}.bad();
+    return ok ? 0 : 1;
+}
+#else
+int main() { return 0; } // the header build does not exercise the module
+#endif

--- a/tests/module_consumer/std_string_module_only.cpp
+++ b/tests/module_consumer/std_string_module_only.cpp
@@ -1,6 +1,5 @@
-// Includes <string> before importing every module which names std::string on its surface.
-// gcc-14 writes a .gcm no such importer can read for some of them, so this target is the gate.
-// test_modules.cpp cannot catch it, because it imports every module at once. See BUGS.md B8.
+// Includes <string> first, then imports every module which names std::string on its surface.
+// gcc-14 writes a .gcm no such importer can read, and test_modules.cpp misses it, see BUGS.md B8.
 #ifdef MAMA_HAS_MODULES
 #include <string> // the include which makes gcc reconcile std::__cxx11 against the module
 

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 #include <mutex>                  // std::unique_lock, which rpp::spin_lock returns
+#include <memory>                 // std::make_shared, which rpp::atomic_shared_ptr takes
 
 import rpp.strview;   // includes come first, the import goes last
 import rpp.debugging;
@@ -38,6 +39,11 @@ import rpp.memory_pool;
 import rpp.mutex;
 import rpp.paths;
 import rpp.tests;
+import rpp.atomic_shared_ptr;
+import rpp.close_sync;
+import rpp.condition_variable;
+import rpp.file_io;
+import rpp.sockets;
 
 // test_modules_identity.cpp takes this address through the module and includes no rpp header
 const void* module_pi_addr() noexcept;
@@ -356,6 +362,72 @@ TestImpl(test_modules)
         AssertThat(info.auto_run, true);
         rpp::test_factory factory = info.factory;
         AssertThat(factory == nullptr, true);
+    }
+
+    TestCase(atomic_shared_ptr_module_carries_the_whole_surface)
+    {
+        rpp::atomic_shared_ptr<int> p { std::make_shared<int>(7) };
+        AssertThat(*p.load(), 7);
+        AssertThat(p.is_lock_free(), false);
+
+        std::shared_ptr<int> old = p.exchange(std::make_shared<int>(9));
+        AssertThat(*old, 7);
+        AssertThat(*p.load(), 9);
+
+        rpp::atomic_weak_ptr<int> w { p.load() };
+        AssertThat(w.load().expired(), false);
+    }
+
+    TestCase(close_sync_module_carries_the_whole_surface)
+    {
+        rpp::close_sync sync;
+        AssertThat(sync.is_alive(), true);
+        AssertThat(sync.is_closing(), false);
+        AssertThat(sync.is_dead_or_closing(), false);
+
+        rpp::readonly_lock shared = sync.try_readonly_lock();
+        AssertThat(shared.owns_lock(), true);
+    }
+
+    TestCase(condition_variable_module_carries_the_whole_surface)
+    {
+        // the deadline already passed, so the helper reports no time left
+        rpp::TimePoint past = rpp::TimePoint::monotonic_now() - rpp::seconds_f(1.0);
+        AssertThat(rpp::_cv_remaining_duration(past).nsec, 0LL);
+
+        rpp::condition_variable cv;
+        rpp::mutex m;
+        std::unique_lock<rpp::mutex> lock { m };
+        AssertThat(cv.wait_for(lock, rpp::millis(1)) == std::cv_status::timeout, true);
+    }
+
+    TestCase(file_io_module_carries_the_whole_surface)
+    {
+        std::string path = rpp::path_combine(rpp::temp_dir(), "rpp_module_probe.txt");
+        AssertThat(rpp::file::write_new(path, "abc", 3), 3);
+
+        rpp::file f { path, rpp::file::READONLY };
+        AssertThat(f.good(), true);
+        AssertThat(f.size(), 3);
+
+        rpp::load_buffer buf = rpp::file::read_all(path);
+        AssertThat(rpp::strview(buf.str, buf.len), "abc");
+        f.close();
+        rpp::delete_file(path);
+    }
+
+    TestCase(sockets_module_carries_the_whole_surface)
+    {
+        rpp::ipaddress addr { rpp::AF_IPv4, "127.0.0.1", 1337 };
+        AssertThat(addr.port(), 1337);
+        AssertThat(addr.is_valid(), true);
+        AssertThat(addr.str(), "127.0.0.1:1337");
+
+        // the platform value differs per system, so the round trip is what the module owes
+        AssertThat(rpp::to_addrfamily(rpp::addrfamily_int(rpp::AF_IPv4)) == rpp::AF_IPv4, true);
+        rpp::socket s = rpp::make_udp_randomport();
+        AssertThat(s.good(), true);
+        AssertGreater(s.port(), 0);
     }
 
 #if RPP_HAS_COROUTINES

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <mutex>                  // std::unique_lock, which rpp::spin_lock returns
 #include <memory>                 // std::make_shared, which rpp::atomic_shared_ptr takes
+#include <type_traits>            // std::is_same_v, which pins an exported signature
 
 import rpp.strview;   // includes come first, the import goes last
 import rpp.debugging;

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -368,7 +368,8 @@ TestImpl(test_modules)
     {
         rpp::atomic_shared_ptr<int> p { std::make_shared<int>(7) };
         AssertThat(*p.load(), 7);
-        AssertThat(p.is_lock_free(), false);
+        // the standard library picks the answer, so this pins the signature and not the value
+        static_assert(std::is_same_v<decltype(p.is_lock_free()), bool>);
 
         std::shared_ptr<int> old = p.exchange(std::make_shared<int>(9));
         AssertThat(*old, 7);

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -58,8 +58,7 @@ INTERNAL_OK = frozenset()
 # importer can read when an export names a std::__cxx11 function, see BUGS.md B8
 NO_EXPORT = {'type_traits.h': frozenset({'has_std_to_string'})}
 
-# the modules a module re-exports. A header leaks whatever its includes pull in, and a module
-# owes an importer no such leak, so this list stays empty until a surface forces an entry.
+# the modules a module re-exports, empty until a surface forces an entry
 # tests.h earns the one: TestImpl expands to a constructor taking rpp::strview
 RE_EXPORT = {'tests.h': ('rpp.strview',)}
 

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -62,7 +62,8 @@ NO_EXPORT = {'type_traits.h': frozenset({'has_std_to_string'})}
 # global module fragment and the module imports it back. It runs out of imported source
 # locations on the eighth re-export of rpp.tests, see BUGS.md B8
 NO_IMPORT = {'task.h': frozenset({'rpp.future_types'}),
-             'tests.h': frozenset({'rpp.future_types', 'rpp.sprint'})}
+             'tests.h': frozenset({'rpp.future_types', 'rpp.sprint'}),
+             'file_io.h': frozenset({'rpp.sprint', 'rpp.paths'})}
 
 # a header which does not compile in a guard configuration, so no export list exists to reduce
 # against. Empty, because every header parses in both. A parse error reaches the caller

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -58,12 +58,10 @@ INTERNAL_OK = frozenset()
 # importer can read when an export names a std::__cxx11 function, see BUGS.md B8
 NO_EXPORT = {'type_traits.h': frozenset({'has_std_to_string'})}
 
-# a re-export the same defect blocks. gcc-14 writes an unreadable .gcm when task.h sits in the
-# global module fragment and the module imports it back. It runs out of imported source
-# locations on the eighth re-export of rpp.tests, see BUGS.md B8
-NO_IMPORT = {'task.h': frozenset({'rpp.future_types'}),
-             'tests.h': frozenset({'rpp.future_types', 'rpp.sprint'}),
-             'file_io.h': frozenset({'rpp.sprint', 'rpp.paths'})}
+# the modules a module re-exports. A header leaks whatever its includes pull in, and a module
+# owes an importer no such leak, so this list stays empty until a surface forces an entry.
+# tests.h earns the one: TestImpl expands to a constructor taking rpp::strview
+RE_EXPORT = {'tests.h': ('rpp.strview',)}
 
 # a header which does not compile in a guard configuration, so no export list exists to reduce
 # against. Empty, because every header parses in both. A parse error reaches the caller
@@ -226,17 +224,8 @@ def export_block(header: str) -> str:
     spans = _guarded_spans(header)
     lines = [BEGIN]
 
-    # one export import per rpp include. config.h maps to rpp.config, and a header never imports itself
-    included = re.findall(r'^\s*#\s*include\s*"([^"]+)"', _read(header), re.M)
-    imports = set()
-    for path in included:
-        inc = os.path.basename(path)  # a `./math.h` or `sub/x.h` include still names module rpp.math
-        if not inc.endswith('.h'): continue
-        if inc == 'config.h': imports.add(CONFIG_MODULE)
-        elif inc not in rd.NO_MODULE: imports.add(module_name(inc))
-    imports.discard(module_name(header))
-    imports -= NO_IMPORT.get(os.path.basename(header), frozenset())
-    lines += [f'export import {imp};' for imp in sorted(imports)]
+    # a module re-exports only what RE_EXPORT names, so an importer spells the rest itself
+    lines += [f'export import {imp};' for imp in sorted(RE_EXPORT.get(os.path.basename(header), ()))]
 
     declared = _declared(base, reduced)
     alt_guard = ALT_GUARD.get(os.path.basename(header), '')
@@ -382,17 +371,17 @@ def selftest() -> list:
                 bad.append('ALT_GUARD did not replace the negated guard')
         finally:
             del ALT_GUARD[os.path.basename(path)]
-        # both defect workarounds drop something a working toolchain would carry
+        # an rpp include is not a re-export, and only RE_EXPORT puts one in the block
         probe = os.path.basename(path)
-        if 'export import rpp.minmax;' not in export_block(path):
-            bad.append('an rpp include did not become an export import')
-        NO_EXPORT[probe], NO_IMPORT[probe] = frozenset({'Public'}), frozenset({'rpp.minmax'})
+        if 'export import' in export_block(path):
+            bad.append('an rpp include became an export import on its own')
+        NO_EXPORT[probe], RE_EXPORT[probe] = frozenset({'Public'}), ('rpp.minmax',)
         try:
             block = export_block(path)
             if 'using rpp::Public;' in block: bad.append('a NO_EXPORT name reached the export list')
-            if 'export import rpp.minmax;' in block: bad.append('a NO_IMPORT module reached the block')
+            if 'export import rpp.minmax;' not in block: bad.append('a RE_EXPORT module left the block')
         finally:
-            del NO_EXPORT[probe], NO_IMPORT[probe]
+            del NO_EXPORT[probe], RE_EXPORT[probe]
         # a header the allowlist does not name must report its parse error, never drop the guard
         broken = os.path.join(d, 'broken.h')
         open(broken, 'w').write('#pragma once\n#if RPP_FREERTOS\n#error this header needs a host\n#endif\n')


### PR DESCRIPTION
Changeset 5 of the modules migration, layer L4. Five modules join, so 36 ship and 8 remain.

`atomic_shared_ptr`, `close_sync`, `condition_variable`, `file_io` and `sockets`. Each one
generated and compiled on the first pass.

## The one real finding is a gate hole

`rpp.file_io` passed every gate this repository has and still shipped broken:

```
import rpp.file_io;      // builds
```
```
#include <string>        // rpp.file_io: error: failed to read compiled module cluster 1452: Bad file data
import rpp.file_io;      // fatal error: failed to load pendings for 'std::__cxx11::basic_string'
```

Every existing gate imports a module with no std header before it, so all 28 CI jobs would
have stayed green while a downstream consumer could not build. That is the part worth
reading twice: the defect is a fourth case of `BUGS.md` **B8**, and nothing we had could see
it.

A bisect names the halves. Dropping every `export import` fixes it with the whole export
list in place, and dropping every export fixes it with all four re-exports in place. So it
is cumulative, not one bad name. `rpp.sprint` is the re-export which carries it, and
`rpp.paths` re-exports `rpp.sprint` in turn. That fix then aged into the section below,
which removes the re-exports outright.

`tests/module_consumer/std_string_module_only.cpp` holds the shape now. It includes
`<string>`, then imports the six modules which name `std::string` on their surface. A
mutation run pins it: giving `file_io.h` its old re-exports back makes that target report 2
errors, and the current policy reports 0.

The same probe passes on the other four L4 modules, and on `rpp.paths`, `rpp.sprint`,
`rpp.collections` and `rpp.tests`. `rpp.file_io` was the only casualty.

## Folded in: a module re-exports nothing

The question the finding above raised: does an importer need those transitive imports at
all? A header leaks whatever its includes pull in, and a module owes an importer no such
leak.

Measured before changing the policy. With all 61 `export import` lines stripped, the 571
case suite stays green and five of the six module-only consumers pass. `RppTestsModuleOnly`
is the sixth, and one line fixes it. `TestImpl` expands to a constructor which takes
`rpp::strview`.

**1 of 61 re-exports was load-bearing.** So `NO_IMPORT`, a drop list of three, becomes
`RE_EXPORT`, an allowlist of one:

```python
RE_EXPORT = {'tests.h': ('rpp.strview',)}
```

A consumer which needs `rpp::strview` from `import rpp.sprint;` writes `import rpp.strview;`
too. One line names what that consumer depends on, and the module hands over nothing else.

B8 shapes 2 and 3 both need a re-export, so neither can fire on one library-wide entry.
D5 in the migration plan carries the reversed rule and the measurement.

## Gates

Every row ran again after the policy change.

| Gate | Result |
|---|---|
| gcc CXX20 and CXX23 | 571/571 |
| clang CXX20 and CXX23 | 538/538 |
| `module_consumer` gcc, `--compare-paths --unicode-off` | every check passed, and `RppStdStringModuleOnly` exits 0 |
| `check_includes all` | 50 missing and 4 unused, unchanged from master |
| `gen_module_exports --all --check` and `--selftest` | 0 over 36 modules, and 0 |
| `update_doc_linerefs` both modes | clean |
| `clang-tidy-18` on the new test bodies | clean |

Android and MSVC ran nowhere local. This box carries no NDK and no Windows mirror, so CI
covers both.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJQak2qMQ4cXHtqEcpwimN


---
_Generated by [Claude Code](https://claude.ai/code/session_01PJQak2qMQ4cXHtqEcpwimN)_