### PR TITLE
modules: the L7 layer, and a gcc-14 crash on std::promise in an importer

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -13,7 +13,7 @@ names the fix. Git holds the story, and a longer entry is noise every agent read
 inherits `std::condition_variable`. That base waits on a `std::unique_lock<std::mutex>`
 only. `mutex.h:155` makes `rpp::mutex` a `critical_section` on bare metal, so every
 `cv.wait(lock)` in `semaphore.h` and `concurrent_queue.h` reports `no matching member
-function for call to 'wait'`. `thread_pool.h`, `future.h` and `event_loop.h` include one
+function for call to 'wait'`. `thread_pool.h`, `future.h` and `event_loop.h` reach one
 of those two, so they report the same.
 
 The MSVC branch at `condition_variable.h:179` is the one which would work. It is a
@@ -21,7 +21,7 @@ hand-rolled `condition_variable` templated on the mutex type. A fix widens the `
 bare metal takes that branch too, and it needs a target which can run the result.
 
 `event_loop.h` carries a second gap of its own. It calls `rpp::get_thread_id()` at lines
-445 and 517, and `threads.h:11` declares that name only when `!RPP_BARE_METAL`.
+445 and 517, and `threads.h:31` declares that name only when `!RPP_BARE_METAL`.
 
 All five headers carry a `NO_CONFIG` entry in `tools/gen_module_exports.py` until then. A
 bare-metal build never reaches the module either, so the export list stays unguarded.
@@ -44,12 +44,14 @@ import m;
 int main() { std::promise<int> p; p.set_value(7); return p.get_future().get() == 7 ? 0 : 1; }
 ```
 
-Eight headers reach `<future>`: `concurrent_queue.h`, `event_loop.h`, `future.h`,
-`future_types.h`, `semaphore.h`, `task.h`, `tests.h` and `thread_pool.h`. Six shipped
-before L7, so this predates the layer which found it. `rpp.task` alone reproduces it.
+Ten headers reach `<future>`, and `future_types.h` is the only direct includer:
+`concurrent_queue.h`, `coroutines.h`, `event_loop.h`, `future.h`, `future_types.h`,
+`semaphore.h`, `task.h`, `tests.h`, `tests.macros.h` and `thread_pool.h`. Eight of them
+ship as a module, six before L7, so this predates the layer which found it. `rpp.task`
+alone reproduces it, and `coroutines.h` inherits it the day L8 ships.
 
-No export list reduces the crash away, so `test_modules.cpp` names the `future.h` factories
-in an unevaluated context. Delete that workaround when a newer gcc compiles the reproducer.
+No export list removes the crash, so `test_modules.cpp` names the `future.h` factories in
+an unevaluated context. Delete that workaround when a newer gcc compiles the reproducer.
 
 ### B2. A test which trusts the clock fails on a loaded machine
 Nearly every timing assertion sets its bound just above the delay it measures. A

--- a/BUGS.md
+++ b/BUGS.md
@@ -8,19 +8,48 @@ names the fix. Git holds the story, and a longer entry is noise every agent read
 
 ## Open
 
-### B15. `semaphore.h`, `concurrent_queue.h` and `thread_pool.h` do not compile on bare metal
+### B15. Five headers do not compile on bare metal
 `condition_variable.h:62` gives every non-MSVC target a `condition_variable` which
 inherits `std::condition_variable`. That base waits on a `std::unique_lock<std::mutex>`
 only. `mutex.h:155` makes `rpp::mutex` a `critical_section` on bare metal, so every
 `cv.wait(lock)` in `semaphore.h` and `concurrent_queue.h` reports `no matching member
-function for call to 'wait'`. `thread_pool.h` includes `semaphore.h`, so it reports the same.
+function for call to 'wait'`. `thread_pool.h`, `future.h` and `event_loop.h` include one
+of those two, so they report the same.
 
 The MSVC branch at `condition_variable.h:179` is the one which would work. It is a
 hand-rolled `condition_variable` templated on the mutex type. A fix widens the `#if` so
 bare metal takes that branch too, and it needs a target which can run the result.
 
-All three headers carry a `NO_CONFIG` entry in `tools/gen_module_exports.py` until then. A
+`event_loop.h` carries a second gap of its own. It calls `rpp::get_thread_id()` at lines
+445 and 517, and `threads.h:11` declares that name only when `!RPP_BARE_METAL`.
+
+All five headers carry a `NO_CONFIG` entry in `tools/gen_module_exports.py` until then. A
 bare-metal build never reaches the module either, so the export list stays unguarded.
+
+### B16. gcc-14 cannot compile `std::promise` in a module importer
+A module whose global module fragment includes `<future>` breaks every importer which
+instantiates `std::promise`. gcc-14 reports `internal compiler error: in
+propagate_necessity, at tree-ssa-dce.cc:1001`. The crash needs no export, and `-O0`
+crashes the same as `-O2`.
+
+```cpp
+// m.cppm
+module;
+#include <future>
+export module m;
+
+// c.cpp
+#include <future>
+import m;
+int main() { std::promise<int> p; p.set_value(7); return p.get_future().get() == 7 ? 0 : 1; }
+```
+
+Eight headers reach `<future>`: `concurrent_queue.h`, `event_loop.h`, `future.h`,
+`future_types.h`, `semaphore.h`, `task.h`, `tests.h` and `thread_pool.h`. Six shipped
+before L7, so this predates the layer which found it. `rpp.task` alone reproduces it.
+
+No export list reduces the crash away, so `test_modules.cpp` names the `future.h` factories
+in an unevaluated context. Delete that workaround when a newer gcc compiles the reproducer.
 
 ### B2. A test which trusts the clock fails on a loaded machine
 Nearly every timing assertion sets its bound just above the delay it measures. A

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,9 @@ if(RPP_BUILD_MODULES)
         # L6
         src/rpp/rpp-binary_serializer.cppm
         src/rpp/rpp-thread_pool.cppm
+        # L7
+        src/rpp/rpp-future.cppm
+        src/rpp/rpp-event_loop.cppm
     )
 
     # Add module interface to the library target

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ preprocessed lines and needs no split.
 
 ### Available modules
 
-Forty-one modules ship. `src/rpp/rpp-*.cppm` names each one, and section 9 of
+Forty-three modules ship. `src/rpp/rpp-*.cppm` names each one, and section 9 of
 [`docs/MODULES_MIGRATION.md`](docs/MODULES_MIGRATION.md) lists them by dependency layer,
 with the ones still to come. Each `.cppm` carries the export list its header earned, so read
 that file for the names a module gives you.
@@ -167,6 +167,13 @@ Six of them carry a limit the export list cannot state:
 | `rpp.type_traits` | [`type_traits.h`](src/rpp/type_traits.h) | Drops `has_std_to_string`, which gcc-14 cannot write into a readable module. The header still declares it, see `BUGS.md` B8 |
 | `rpp.memory_pool` | [`memory_pool.h`](src/rpp/memory_pool.h) | Drops `pool_types_constructor`, an internal mixin. Each pool still gives you `construct<T>()` and the array forms |
 | `rpp.thread_pool` | [`thread_pool.h`](src/rpp/thread_pool.h) | Drops `test_threadpool`, the forward declaration a unit test needs as a friend |
+
+Eight headers reach `<future>`, so the modules which wrap them carry one more limit. On
+gcc-14 an importer of `rpp.concurrent_queue`, `rpp.event_loop`, `rpp.future`,
+`rpp.future_types`, `rpp.semaphore`, `rpp.task`, `rpp.tests` or `rpp.thread_pool` cannot
+instantiate `std::promise`. The compiler crashes, no export list changes it, and
+`BUGS.md` B16 holds the reproducer. Include the header on that path until a newer gcc
+lands.
 
 ### How it works
 

--- a/README.md
+++ b/README.md
@@ -168,12 +168,12 @@ Six of them carry a limit the export list cannot state:
 | `rpp.memory_pool` | [`memory_pool.h`](src/rpp/memory_pool.h) | Drops `pool_types_constructor`, an internal mixin. Each pool still gives you `construct<T>()` and the array forms |
 | `rpp.thread_pool` | [`thread_pool.h`](src/rpp/thread_pool.h) | Drops `test_threadpool`, the forward declaration a unit test needs as a friend |
 
-Eight headers reach `<future>`, so the modules which wrap them carry one more limit. On
+Eight modules wrap a header which reaches `<future>`, so each carries one more limit. On
 gcc-14 an importer of `rpp.concurrent_queue`, `rpp.event_loop`, `rpp.future`,
 `rpp.future_types`, `rpp.semaphore`, `rpp.task`, `rpp.tests` or `rpp.thread_pool` cannot
 instantiate `std::promise`. The compiler crashes, no export list changes it, and
-`BUGS.md` B16 holds the reproducer. Include the header on that path until a newer gcc
-lands.
+`BUGS.md` B16 holds the reproducer. Include the header in a translation unit which
+instantiates `std::promise`.
 
 ### How it works
 

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -40,8 +40,8 @@ compile on bare metal, see **B15**. The generator selftest still pins all three 
 **gcc-14 cannot compile `std::promise` in an importer, and six modules carried that before
 L7.** Any module whose global module fragment includes `<future>` breaks such a consumer,
 and `rpp.task` alone reproduces it. No export list changes the crash, so the L7 tests name
-the `future.h` factories in an unevaluated context. **B16** holds the seven-line reproducer
-and the list of eight headers which reach `<future>`.
+the `future.h` factories in an unevaluated context. **B16** holds the reproducer and the
+list of ten headers which reach `<future>`. `coroutines.h` is one, so L8 inherits the limit.
 
 **An importer which includes `<string>` first reads a different module.** `rpp.file_io`
 passed every gate and still broke that consumer, so `std_string_module_only.cpp` holds the

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -1,9 +1,9 @@
 # ReCpp C++20 Modules Migration Plan
 
-Revision 15. Forty-one modules exist: all of L0 to L6. Only `rpp.tests` re-exports another.
+Revision 16. Forty-three modules exist: all of L0 to L7. Only `rpp.tests` re-exports another.
 
 This document explains the pattern, records what real builds prove about it, and
-gives the phased plan for the remaining 3 headers.
+gives the phased plan for the remaining 1 header.
 
 ## Handover state
 
@@ -12,31 +12,36 @@ gate, #65 changeset 6.
 
 | Item | State |
 |---|---|
-| the forty-one modules | build and pass on gcc-14, and CI covers clang-21 and MSVC 14.52 |
+| the forty-three modules | build and pass on gcc-14, and CI covers clang-21 and MSVC 14.52 |
 | `debugging.macros.h` | split out, 50 preprocessed lines against 32893 |
 | `BUILD_WITH_MODULES=AUTO` | on per toolchain, GCC 14 / Clang 21 / MSVC 19.34 |
 | Include-order style rule | in AGENTS.md, and the `import-order` gate holds it |
 | `tools/check_includes.py` | 6 checks. 4 gate CI, and `missing` and `unused` stay ungated |
-| `tests/test_modules.cpp` | module consumer test, 38 cases. It includes `tests.h` and the macro header only, so what those two mask needs a module-only target |
+| `tests/test_modules.cpp` | module consumer test, 40 cases. It includes `tests.h` and the macro header only, so what those two mask needs a module-only target |
 | `tests/module_consumer/` | a real mama consumer, on gcc, clang and MSVC, with 6 module-only targets |
 | mama | 0.14.0 exports the `.cppm` files and strips the module objects |
 | CI | 28 jobs on GitHub Actions, and CircleCI is gone |
-| test counts | 576/576 on the modules build, 538/538 on the header build |
+| test counts | 578/578 on the modules build, 538/538 on the header build |
 
 **Changeset state:** 1a is dropped, see section 4. 1b, 2, 3 and the mama half of
-6 landed. The generator drives all forty-one modules. 4 is done through the generator
-`--check`. 5 has L0 to L6 finished. Section 11 lists what 7 owes.
+6 landed. The generator drives all forty-three modules. 4 is done through the generator
+`--check`. 5 has L0 to L7 finished. Section 11 lists what 7 owes.
 
-**Next:** changeset 5, the L7 layer. Section 9 has the layers.
+**Next:** changeset 5, the L8 layer and the umbrella. Section 9 has the layers.
 
 **A module re-exports nothing, and two headers ship with a workaround.** The generator
 carries `NO_EXPORT` with three entries and `RE_EXPORT` with one, and `BUGS.md` **B8** names
 the four shapes gcc-14 breaks. Shapes 2 and 3 both need a re-export, so neither can fire on
 one library-wide entry. Shape 4 lives in `binary_stream.h`, whose destructor moved out of
 line. The other two `NO_EXPORT` entries are internal names, a CRTP mixin and a unit-test
-friend, and no gcc defect drives them. `NO_CONFIG` names `semaphore.h`, `concurrent_queue.h`
-and `thread_pool.h`, which do not compile on bare metal, see **B15**. The generator selftest
-still pins all three knobs.
+friend, and no gcc defect drives them. `NO_CONFIG` names the five headers which do not
+compile on bare metal, see **B15**. The generator selftest still pins all three knobs.
+
+**gcc-14 cannot compile `std::promise` in an importer, and six modules carried that before
+L7.** Any module whose global module fragment includes `<future>` breaks such a consumer,
+and `rpp.task` alone reproduces it. No export list changes the crash, so the L7 tests name
+the `future.h` factories in an unevaluated context. **B16** holds the seven-line reproducer
+and the list of eight headers which reach `<future>`.
 
 **An importer which includes `<string>` first reads a different module.** `rpp.file_io`
 passed every gate and still broke that consumer, so `std_string_module_only.cpp` holds the
@@ -95,7 +100,7 @@ only it can offer, the vector overload an explicit `rpp::sort<T>(v)` names, and 
 `element_range` overload whose by-value parameter lets a const view sort its mutable
 elements. Asking which module should carry a name is worth doing per layer.
 
-**Open questions:** `BUGS.md` B2, B5, B9, B10 and B15. B8 keeps three workarounds open,
+**Open questions:** `BUGS.md` B2, B5, B9, B10, B15 and B16. B8 keeps three workarounds open,
 and each one goes away when a newer gcc reads the module back. B6 closed as C25, so the TSAN jobs no
 longer fail on the exception refcount race.
 
@@ -807,13 +812,13 @@ between layers.
 | L4 | **atomic_shared_ptr** ✓, **close_sync** ✓, **condition_variable** ✓, **file_io** ✓, **sockets** ✓ | 5 |
 | L5 | **binary_stream** ✓, **concurrent_queue** ✓, **semaphore** ✓ | 3 |
 | L6 | **binary_serializer** ✓, **thread_pool** ✓ | 2 |
-| L7 | event_loop, future | 2 |
+| L7 | **event_loop** ✓, **future** ✓ | 2 |
 | L8 | coroutines | 1 |
 | top | umbrella `rpp` | 1 |
 
-Every L6 module ships. `BUILD_WITH_MODULES` builds all forty-one.
+Every L7 module ships. `BUILD_WITH_MODULES` builds all forty-three.
 
-44 modules and one umbrella. L0 to L6 exist, so 3 remain. Excluded: `config.h`
+44 modules and one umbrella. L0 to L7 exist, so 1 remains. Excluded: `config.h`
 and `log_colors.h` by rule 1 of section 6.3, and `jni_cpp.h` because it is
 Android glue. `tests.h` is in, and it is the one header whose macros split into
 `tests.macros.h`.
@@ -942,7 +947,7 @@ Then port one real consumer. `krattcam` and `krattlink` both pull ReCpp through
 | 2 | add the rpp-header include check | 0.5 | changeset 3 | done |
 | 3 | generate the export lists | 1.5 | changeset 5 | done |
 | 4 | dual-mode test harness | 0.5 | changeset 5 | done, the generator --check is the gate |
-| 5 | 44 modules plus the umbrella | 2.5 | changeset 6 | 41 of 44 written |
+| 5 | 44 modules plus the umbrella | 2.5 | changeset 6 | 43 of 44 written |
 | 6 | mama and CMake packaging, consumer example | 1.5 | changeset 7 | mama done, PR #65 |
 | 7 | CI, docs, measurement | 0.5 | none | gates done |
 

--- a/src/rpp/rpp-event_loop.cppm
+++ b/src/rpp/rpp-event_loop.cppm
@@ -1,0 +1,17 @@
+// C++20 module interface unit for <rpp/event_loop.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "event_loop.h"
+
+export module rpp.event_loop;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+
+export namespace rpp {
+#if RPP_HAS_COROUTINES
+    using rpp::event_task;
+    using rpp::event_loop;
+#endif
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-future.cppm
+++ b/src/rpp/rpp-future.cppm
@@ -1,0 +1,21 @@
+// C++20 module interface unit for <rpp/future.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "future.h"
+
+export module rpp.future;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+
+export namespace rpp {
+    using rpp::cpromise;
+    using rpp::async_task;
+    using rpp::cfuture;
+    using rpp::make_ready_future;
+    using rpp::make_exceptional_future;
+    using rpp::wait_all;
+    using rpp::get_all;
+    using rpp::run_tasks;
+}
+// GENERATED EXPORTS END

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -14,6 +14,7 @@
 #include <memory>                 // std::make_shared, which rpp::atomic_shared_ptr takes
 #include <type_traits>            // std::is_same_v, which pins an exported signature
 #include <atomic>                 // std::atomic_bool, which rpp::atomic_test_and_set takes
+#include <future>                 // std::promise, which rpp::cpromise aliases
 
 import rpp.strview;   // includes come first, the import goes last
 import rpp.debugging;
@@ -51,6 +52,8 @@ import rpp.concurrent_queue;
 import rpp.semaphore;
 import rpp.binary_serializer;
 import rpp.thread_pool;
+import rpp.future;
+import rpp.event_loop;
 
 // test_modules_identity.cpp takes this address through the module and includes no rpp header
 const void* module_pi_addr() noexcept;
@@ -558,6 +561,24 @@ TestImpl(test_modules)
         AssertThat(summed.load(), 7);
     }
 
+    TestCase(future_module_carries_the_whole_surface)
+    {
+        // every factory here builds a std::promise, which gcc-14 cannot compile in an
+        // importer, see BUGS.md B16. So this probe reaches the surface without one.
+        static_assert(std::is_same_v<rpp::cpromise<int>, std::promise<int>>);
+        static_assert(std::is_same_v<decltype(rpp::async_task(+[]{ return 1; })), rpp::cfuture<int>>);
+        static_assert(std::is_same_v<decltype(rpp::make_ready_future(1)), rpp::cfuture<int>>);
+        static_assert(std::is_same_v<decltype(rpp::make_exceptional_future<int>(1)), rpp::cfuture<int>>);
+
+        std::vector<rpp::cfuture<int>> none;
+        rpp::wait_all(none);
+        AssertThat(int(rpp::get_all(none).size()), 0);
+
+        std::vector<int> no_items;
+        rpp::run_tasks(no_items, [](int&) { return rpp::cfuture<void>{}; });
+        AssertThat(int(no_items.size()), 0);
+    }
+
 #if RPP_HAS_COROUTINES
     // an eager task runs to completion at construction, so this needs no event loop
     static rpp::task<int> module_task() { co_return 99; }
@@ -568,6 +589,26 @@ TestImpl(test_modules)
         AssertThat(t.valid(), true);
         AssertThat(t.done(), true);
         AssertThat(t.await_ready(), true);
+    }
+
+    // event_task starts eagerly, so one with no co_await ends before the caller sees it
+    static rpp::event_task module_event_task(int* out) { *out = 3; co_return; }
+
+    TestCase(event_loop_module_carries_the_whole_surface)
+    {
+        rpp::event_loop loop;
+        AssertThat(loop.main_thread_id(), rpp::get_thread_id());
+        AssertThat(loop.has_pending_work(), false);
+
+        int posted = 0;
+        loop.post([&] { ++posted; });
+        loop.run_until_idle();
+        AssertThat(posted, 1);
+
+        int value = 0;
+        rpp::event_task task = module_event_task(&value);
+        AssertThat(value, 3);
+        AssertThat(task.done(), true);
     }
 #endif
 };

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -566,20 +566,23 @@ TestImpl(test_modules)
 
     TestCase(future_module_carries_the_whole_surface)
     {
-        // every factory here builds a std::promise, which gcc-14 cannot compile in an
-        // importer, see BUGS.md B16. So this probe reaches the surface without one.
+        // gcc-14 crashes when an importer instantiates std::promise, so name these unevaluated, see BUGS.md B16
         static_assert(std::is_same_v<rpp::cpromise<int>, std::promise<int>>);
         static_assert(std::is_same_v<decltype(rpp::async_task(+[]{ return 1; })), rpp::cfuture<int>>);
         static_assert(std::is_same_v<decltype(rpp::make_ready_future(1)), rpp::cfuture<int>>);
+        static_assert(std::is_same_v<decltype(rpp::make_ready_future()), rpp::cfuture<void>>);
         static_assert(std::is_same_v<decltype(rpp::make_exceptional_future<int>(1)), rpp::cfuture<int>>);
 
-        std::vector<rpp::cfuture<int>> none;
-        rpp::wait_all(none);
-        AssertThat(int(rpp::get_all(none).size()), 0);
+        // a filled vector needs a real cfuture, and every way to build one runs a promise
+        std::vector<rpp::cfuture<int>> no_ints;
+        rpp::wait_all(no_ints);
+        AssertThat(int(rpp::get_all(no_ints).size()), 0);
+
+        std::vector<rpp::cfuture<void>> no_voids;
+        rpp::get_all(no_voids);
 
         std::vector<int> no_items;
         rpp::run_tasks(no_items, &module_launch);
-        AssertThat(int(no_items.size()), 0);
     }
 
 #if RPP_HAS_COROUTINES

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -561,6 +561,9 @@ TestImpl(test_modules)
         AssertThat(summed.load(), 7);
     }
 
+    // clang rejects a plain function which returns a cfuture, so the launcher takes the wrapper
+    RPP_CORO_WRAPPER static rpp::cfuture<void> module_launch(int&) { return {}; }
+
     TestCase(future_module_carries_the_whole_surface)
     {
         // every factory here builds a std::promise, which gcc-14 cannot compile in an
@@ -575,7 +578,7 @@ TestImpl(test_modules)
         AssertThat(int(rpp::get_all(none).size()), 0);
 
         std::vector<int> no_items;
-        rpp::run_tasks(no_items, [](int&) { return rpp::cfuture<void>{}; });
+        rpp::run_tasks(no_items, &module_launch);
         AssertThat(int(no_items.size()), 0);
     }
 

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -66,8 +66,8 @@ NO_EXPORT = {'type_traits.h': frozenset({'has_std_to_string'}),
 # tests.h earns the one: TestImpl expands to a constructor taking rpp::strview
 RE_EXPORT = {'tests.h': ('rpp.strview',)}
 
-# a header which does not compile in a guard configuration, so no export list exists to reduce
-# against. Each one waits on a std::mutex the bare-metal build does not have, see BUGS.md B15
+# a header which does not compile in a guard configuration, so no export list exists to
+# reduce against. Every entry below names a bare-metal gap, see BUGS.md B15
 NO_CONFIG = {'semaphore.h': frozenset({'!RPP_BARE_METAL'}),
              'concurrent_queue.h': frozenset({'!RPP_BARE_METAL'}),
              'thread_pool.h': frozenset({'!RPP_BARE_METAL'}),

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -70,7 +70,9 @@ RE_EXPORT = {'tests.h': ('rpp.strview',)}
 # against. Each one waits on a std::mutex the bare-metal build does not have, see BUGS.md B15
 NO_CONFIG = {'semaphore.h': frozenset({'!RPP_BARE_METAL'}),
              'concurrent_queue.h': frozenset({'!RPP_BARE_METAL'}),
-             'thread_pool.h': frozenset({'!RPP_BARE_METAL'})}
+             'thread_pool.h': frozenset({'!RPP_BARE_METAL'}),
+             'future.h': frozenset({'!RPP_BARE_METAL'}),
+             'event_loop.h': frozenset({'!RPP_BARE_METAL'})}
 
 # the condition a header declares for the names only an alternate configuration has, when the
 # guard the generator would negate is wider. mutex.h also declares critical_section on Cortex-M,


### PR DESCRIPTION
Two modules join, so 43 ship and 1 header remains. `future` and `event_loop`.

## gcc-14 cannot compile `std::promise` in a module importer

A module whose global module fragment includes `<future>` breaks every importer which
instantiates `std::promise`. gcc-14 reports `internal compiler error: in propagate_necessity,
at tree-ssa-dce.cc:1001`. The module need not export anything, and `-O0` crashes the same as
`-O2`, so no export list removes it.

```cpp
// m.cppm
module;
#include <future>
export module m;

// c.cpp
#include <future>
import m;
int main() { std::promise<int> p; p.set_value(7); return p.get_future().get() == 7 ? 0 : 1; }
```

**Six modules carried this before L7.** Ten headers reach `<future>`, and `future_types.h` is
the only direct includer: `concurrent_queue.h`, `coroutines.h`, `event_loop.h`, `future.h`,
`future_types.h`, `semaphore.h`, `task.h`, `tests.h`, `tests.macros.h` and `thread_pool.h`.
Eight of them ship as a module, six before L7. `rpp.task` alone reproduces the crash against
master, and `coroutines.h` inherits it the day L8 ships. No test instantiated `std::promise`
until now, which is why the L7 probe found it. B16 records it, and README.md states the limit
for a consumer.

## What the L7 probe does instead

`future_module_carries_the_whole_surface` names `cpromise`, `async_task`, both
`make_ready_future` overloads and `make_exceptional_future` in an unevaluated `decltype`. It
calls `wait_all`, both `get_all` overloads and `run_tasks` on empty containers. That reaches
all ten exported overloads of `rpp.future` and instantiates no `std::promise`.

`event_loop_module_carries_the_whole_surface` drives a real loop through `post()` and
`run_until_idle()`, and starts an `event_task` with no `co_await`.

## Bare metal

`future.h` and `event_loop.h` join `NO_CONFIG`. Both reach the `cv.wait(lock)` of B15,
`future.h` through `thread_pool.h` and `event_loop.h` through `semaphore.h` directly.
`event_loop.h` carries a second gap of its own: it calls `rpp::get_thread_id()` at lines 445
and 517, and `threads.h:31` declares that name only when `!RPP_BARE_METAL`. B15 now names five
headers and both gaps.

## Review rounds

CI caught what this container cannot build. `ubuntu-cpp20-modules-clang21` rejected a lambda
which returned a `cfuture` without the coroutine-wrapper attribute, the shape the migration
plan records as finding 16. A named launcher marked `RPP_CORO_WRAPPER` replaces it.

A scoped review then found the probe reached eight of the ten exported overloads. The void
`make_ready_future` and the void `get_all` are separate inline functions which the same
using-declaration exports, and B8 already broke that shape three times. Both are named now.

## Gates

| Gate | Result |
|---|---|
| `CXX20=1 mama gcc build test="nogdb -vv"` | 578/578 |
| `CXX23=1 mama gcc build test="nogdb -vv"` | 578/578 |
| `CXX20=1 mama clang build test="nogdb -vv"` | 538/538 |
| `CXX23=1 mama clang build test="nogdb -vv"` | 538/538 |
| `CXX23=1 mama clang build clang-tidy test="nogdb -vv"` | 538/538 |
| `tools/check_includes.py all` | the 4 gated checks report 0, `missing` 50 and `unused` 4 unchanged |
| `gen_module_exports.py --selftest` and `--all --check` | 0, and 0 over 43 modules |
| `update_doc_linerefs.py` and `--check-undocumented` | clean |
| `tests/module_consumer/run_test.py --compare-paths --unicode-off g++` | OK, and the module path matches the header path |
| GitHub Actions CI | all 28 jobs pass on the current head |
| Android NDK, Windows MSVC | NOT RUN here, this container has no NDK and no Windows mirror. CI covers both |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJQak2qMQ4cXHtqEcpwimN