### PR TITLE
modules: the L8 layer, so every header ships and only the umbrella remains

### DIFF
--- a/.claude/skills/recpp-review/SKILL.md
+++ b/.claude/skills/recpp-review/SKILL.md
@@ -83,7 +83,7 @@ clang++ 18 to 21, iOS and macOS Apple Clang, Raspberry Pi, MIPSEL g++ 11.
 
 - A platform API needs a guard from `config.h`: `_MSC_VER`, `RPP_MSVC_WIN`,
   `RPP_ANDROID`, `__APPLE__`, `YOCTO_LINUX`, `MIPS`, `RASPI`, `RPP_ENABLE_UNICODE`,
-  `RPP_HAS_CXX20`. Do not invent a new macro name.
+  `RPP_BARE_METAL`. Do not invent a new macro name.
 - Prefer the ReCpp abstraction over the platform call: `rpp::TimePoint`,
   `rpp::Duration`, `rpp::mutex`, `rpp::semaphore`, `rpp::file_io`, `rpp::paths`,
   `rpp::threads`.

--- a/.claude/skills/recpp-review/SKILL.md
+++ b/.claude/skills/recpp-review/SKILL.md
@@ -83,7 +83,7 @@ clang++ 18 to 21, iOS and macOS Apple Clang, Raspberry Pi, MIPSEL g++ 11.
 
 - A platform API needs a guard from `config.h`: `_MSC_VER`, `RPP_MSVC_WIN`,
   `RPP_ANDROID`, `__APPLE__`, `YOCTO_LINUX`, `MIPS`, `RASPI`, `RPP_ENABLE_UNICODE`,
-  `RPP_HAS_COROUTINES`, `RPP_HAS_CXX20`. Do not invent a new macro name.
+  `RPP_HAS_CXX20`. Do not invent a new macro name.
 - Prefer the ReCpp abstraction over the platform call: `rpp::TimePoint`,
   `rpp::Duration`, `rpp::mutex`, `rpp::semaphore`, `rpp::file_io`, `rpp::paths`,
   `rpp::threads`.

--- a/BUGS.md
+++ b/BUGS.md
@@ -8,6 +8,24 @@ names the fix. Git holds the story, and a longer entry is noise every agent read
 
 ## Open
 
+### B17. A pool worker frees the generic task a test still reads (C18 recurred)
+`ubuntu-cpp23-tsan-gcc13` reported one race in `test_threadpool::parallel_task_reentrance`.
+A worker calls `free` through `generic.reset()` at `thread_pool.cpp:359`, and the main
+thread read the same address in `rpp::test::run_test_func()` at `tests.cpp:726`. All
+538 cases passed, and TSAN alone sets exit code 66.
+
+That statement is what C18 closed. It sat at `thread_pool.cpp:351` then, so the line moved
+and the code did not. C18 closed it as unreproducible after 120 runs on 32 saturated cores.
+This is the first report since, so the rate is far below what the old hunt covered.
+
+The thread which frees comes from an earlier suite. Its creation stack names
+`parallel_task_detached` under `test_sockets::test_udp_poll_nonblocking_select`, so a
+detached task outlives the suite which started it. Suite shutdown order is the place to
+look, not the `catch` block which reports the write.
+
+Four other TSAN jobs pass on the same commit: `cpp20-tsan-gcc13`, `cpp20-tsan-clang18`,
+`cpp23-tsan-clang18` and `cpp26-tsan-gcc14`.
+
 ### B15. Six headers do not compile on bare metal
 `condition_variable.h:62` gives every non-MSVC target a `condition_variable` which
 inherits `std::condition_variable`. That base waits on a `std::unique_lock<std::mutex>`

--- a/BUGS.md
+++ b/BUGS.md
@@ -48,7 +48,7 @@ Ten headers reach `<future>`, and `future_types.h` is the only direct includer:
 `concurrent_queue.h`, `coroutines.h`, `event_loop.h`, `future.h`, `future_types.h`,
 `semaphore.h`, `task.h`, `tests.h`, `tests.macros.h` and `thread_pool.h`. Nine of them
 ship as a module, six before L7, so this predates the layer which found it. `rpp.task`
-alone reproduces it, and only `tests.macros.h` never becomes a module.
+alone reproduces it.
 
 No export list removes the crash, so `test_modules.cpp` names the `future.h` factories in
 an unevaluated context. Delete that workaround when a newer gcc compiles the reproducer.

--- a/BUGS.md
+++ b/BUGS.md
@@ -8,13 +8,13 @@ names the fix. Git holds the story, and a longer entry is noise every agent read
 
 ## Open
 
-### B15. Five headers do not compile on bare metal
+### B15. Six headers do not compile on bare metal
 `condition_variable.h:62` gives every non-MSVC target a `condition_variable` which
 inherits `std::condition_variable`. That base waits on a `std::unique_lock<std::mutex>`
 only. `mutex.h:155` makes `rpp::mutex` a `critical_section` on bare metal, so every
 `cv.wait(lock)` in `semaphore.h` and `concurrent_queue.h` reports `no matching member
-function for call to 'wait'`. `thread_pool.h`, `future.h` and `event_loop.h` reach one
-of those two, so they report the same.
+function for call to 'wait'`. `thread_pool.h`, `future.h`, `event_loop.h` and
+`coroutines.h` reach one of those two, so they report the same.
 
 The MSVC branch at `condition_variable.h:179` is the one which would work. It is a
 hand-rolled `condition_variable` templated on the mutex type. A fix widens the `#if` so
@@ -23,7 +23,7 @@ bare metal takes that branch too, and it needs a target which can run the result
 `event_loop.h` carries a second gap of its own. It calls `rpp::get_thread_id()` at lines
 445 and 517, and `threads.h:31` declares that name only when `!RPP_BARE_METAL`.
 
-All five headers carry a `NO_CONFIG` entry in `tools/gen_module_exports.py` until then. A
+All six headers carry a `NO_CONFIG` entry in `tools/gen_module_exports.py` until then. A
 bare-metal build never reaches the module either, so the export list stays unguarded.
 
 ### B16. gcc-14 cannot compile `std::promise` in a module importer
@@ -46,9 +46,9 @@ int main() { std::promise<int> p; p.set_value(7); return p.get_future().get() ==
 
 Ten headers reach `<future>`, and `future_types.h` is the only direct includer:
 `concurrent_queue.h`, `coroutines.h`, `event_loop.h`, `future.h`, `future_types.h`,
-`semaphore.h`, `task.h`, `tests.h`, `tests.macros.h` and `thread_pool.h`. Eight of them
+`semaphore.h`, `task.h`, `tests.h`, `tests.macros.h` and `thread_pool.h`. Nine of them
 ship as a module, six before L7, so this predates the layer which found it. `rpp.task`
-alone reproduces it, and `coroutines.h` inherits it the day L8 ships.
+alone reproduces it, and only `tests.macros.h` never becomes a module.
 
 No export list removes the crash, so `test_modules.cpp` names the `future.h` factories in
 an unevaluated context. Delete that workaround when a newer gcc compiles the reproducer.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,6 +398,8 @@ if(RPP_BUILD_MODULES)
         # L7
         src/rpp/rpp-future.cppm
         src/rpp/rpp-event_loop.cppm
+        # L8
+        src/rpp/rpp-coroutines.cppm
     )
 
     # Add module interface to the library target

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ preprocessed lines and needs no split.
 
 ### Available modules
 
-Forty-three modules ship. `src/rpp/rpp-*.cppm` names each one, and section 9 of
+Forty-four modules ship. `src/rpp/rpp-*.cppm` names each one, and section 9 of
 [`docs/MODULES_MIGRATION.md`](docs/MODULES_MIGRATION.md) lists them by dependency layer,
 with the ones still to come. Each `.cppm` carries the export list its header earned, so read
 that file for the names a module gives you.
@@ -168,12 +168,12 @@ Six of them carry a limit the export list cannot state:
 | `rpp.memory_pool` | [`memory_pool.h`](src/rpp/memory_pool.h) | Drops `pool_types_constructor`, an internal mixin. Each pool still gives you `construct<T>()` and the array forms |
 | `rpp.thread_pool` | [`thread_pool.h`](src/rpp/thread_pool.h) | Drops `test_threadpool`, the forward declaration a unit test needs as a friend |
 
-Eight modules wrap a header which reaches `<future>`, so each carries one more limit. On
-gcc-14 an importer of `rpp.concurrent_queue`, `rpp.event_loop`, `rpp.future`,
-`rpp.future_types`, `rpp.semaphore`, `rpp.task`, `rpp.tests` or `rpp.thread_pool` cannot
-instantiate `std::promise`. The compiler crashes, no export list changes it, and
-`BUGS.md` B16 holds the reproducer. Include the header in a translation unit which
-instantiates `std::promise`.
+Nine modules wrap a header which reaches `<future>`, so each carries one more limit. On
+gcc-14 an importer of `rpp.concurrent_queue`, `rpp.coroutines`, `rpp.event_loop`,
+`rpp.future`, `rpp.future_types`, `rpp.semaphore`, `rpp.task`, `rpp.tests` or
+`rpp.thread_pool` cannot instantiate `std::promise`. The compiler crashes, no export list
+changes it, and `BUGS.md` B16 holds the reproducer. Include the header in a translation
+unit which instantiates `std::promise`.
 
 ### How it works
 

--- a/README.md
+++ b/README.md
@@ -1345,10 +1345,10 @@ Composable futures with C++20 coroutine support. Uses `rpp/thread_pool.h` for ba
 |------|-------------|
 | [`cfuture<T>`](src/rpp/future.h#L134) | Extended `std::future` with composition and coroutine support |
 | [`async_task(task)`](src/rpp/future.h#L33) | Launch a task on the thread pool, returns `cfuture<T>` |
-| [`make_ready_future(value)`](src/rpp/future.h#L959) | Create an already-completed future |
-| [`make_exceptional_future(e)`](src/rpp/future.h#L976) | Create an already-errored future |
-| [`wait_all(futures)`](src/rpp/future.h#L1044) | Block until all futures complete |
-| [`get_all(futures)`](src/rpp/future.h#L998) | Block and gather results from all futures |
+| [`make_ready_future(value)`](src/rpp/future.h#L955) | Create an already-completed future |
+| [`make_exceptional_future(e)`](src/rpp/future.h#L972) | Create an already-errored future |
+| [`wait_all(futures)`](src/rpp/future.h#L1040) | Block until all futures complete |
+| [`get_all(futures)`](src/rpp/future.h#L994) | Block and gather results from all futures |
 
 ### cfuture Methods
 
@@ -1367,18 +1367,16 @@ Composable futures with C++20 coroutine support. Uses `rpp/thread_pool.h` for ba
 | [`await_ready()`](src/rpp/future.h#L410) | Non-blocking check if the future is already finished |
 | [`collect_ready(T* result)`](src/rpp/future.h#L441) | If already finished, collects the result into `*result` (non-blocking). Returns `true` if collected |
 | [`collect_wait(T* result)`](src/rpp/future.h#L459) | If valid, blocks until finished and collects the result into `*result`. Returns `true` if collected |
-| [`await_suspend(coro_handle<>)`](src/rpp/future.h#L471) | C++20 coroutine suspension point — waits on background thread, then resumes |
-| [`await_resume()`](src/rpp/future.h#L483) | C++20 coroutine resume — returns the result, rethrows exceptions |
-| [`promise_type`](src/rpp/future.h#L510) | C++20 coroutine promise enabling `rpp::cfuture<T>` as a coroutine return type |
-| [`RPP_HAS_COROUTINES`](src/rpp/future_types.h#L12) | Detects whether C++20 coroutine headers are available |
-| [`RPP_CORO_STD`](src/rpp/future_types.h#L13) | Namespace alias for coroutine types (std or std::experimental) |
-| [`coro_handle<T>`](src/rpp/future_types.h#L46) | Alias for the standard coroutine handle, which follows `RPP_CORO_STD` |
-| [`suspend_never`](src/rpp/future_types.h#L47) | Alias for the standard never-suspend awaiter |
-| [`suspend_always`](src/rpp/future_types.h#L48) | Alias for the standard always-suspend awaiter |
-| [`IsFuture`](src/rpp/future_types.h#L55) | Concept which matches `rpp::cfuture<T>` and `std::future<T>` |
-| [`NotFuture`](src/rpp/future_types.h#L61) | Concept which matches any type `IsFuture` rejects |
-| [`IsFunction`](src/rpp/future_types.h#L64) | Concept which matches a callable taking no argument |
-| [`IsFunctionReturningFuture`](src/rpp/future_types.h#L67) | Concept which matches a callable returning a future |
+| [`await_suspend(coro_handle<>)`](src/rpp/future.h#L470) | C++20 coroutine suspension point — waits on background thread, then resumes |
+| [`await_resume()`](src/rpp/future.h#L482) | C++20 coroutine resume — returns the result, rethrows exceptions |
+| [`promise_type`](src/rpp/future.h#L509) | C++20 coroutine promise enabling `rpp::cfuture<T>` as a coroutine return type |
+| [`coro_handle<T>`](src/rpp/future_types.h#L18) | Alias for `std::coroutine_handle<T>` |
+| [`suspend_never`](src/rpp/future_types.h#L19) | Alias for the standard never-suspend awaiter |
+| [`suspend_always`](src/rpp/future_types.h#L20) | Alias for the standard always-suspend awaiter |
+| [`IsFuture`](src/rpp/future_types.h#L26) | Concept which matches `rpp::cfuture<T>` and `std::future<T>` |
+| [`NotFuture`](src/rpp/future_types.h#L32) | Concept which matches any type `IsFuture` rejects |
+| [`IsFunction`](src/rpp/future_types.h#L35) | Concept which matches a callable taking no argument |
+| [`IsFunctionReturningFuture`](src/rpp/future_types.h#L38) | Concept which matches a callable returning a future |
 
 ### Example: Composable Futures
 
@@ -1502,12 +1500,12 @@ Neither is a future: there is no `get()`/`wait()`/`.then()` — drive by `co_awa
 
 | Type | Description |
 |------|-------------|
-| [`task<T>`](src/rpp/task.h#L63) | Eager coroutine; body runs at construction. `co_await` resumes the caller on its loop |
-| [`deferred<T>`](src/rpp/task.h#L65) | Lazy coroutine; body runs only when first awaited / `start()`ed. Same API as `task` |
-| [`done()`](src/rpp/task.h#L179) | True once resolved; lets a driver poll completion without awaiting (no `wait()`) |
-| [`deferred<T>::start()`](src/rpp/task.h#L233) | Launch a not-yet-awaited deferred (used by `run_until_done`) |
+| [`task<T>`](src/rpp/task.h#L62) | Eager coroutine; body runs at construction. `co_await` resumes the caller on its loop |
+| [`deferred<T>`](src/rpp/task.h#L64) | Lazy coroutine; body runs only when first awaited / `start()`ed. Same API as `task` |
+| [`done()`](src/rpp/task.h#L178) | True once resolved; lets a driver poll completion without awaiting (no `wait()`) |
+| [`deferred<T>::start()`](src/rpp/task.h#L232) | Launch a not-yet-awaited deferred (used by `run_until_done`) |
 
-Drive a top-level task to completion with [`event_loop::run_until_done(task<T>&)`](src/rpp/event_loop.h#L334) or [`run_until_done(deferred<T>&)`](src/rpp/event_loop.h#L363).
+Drive a top-level task to completion with [`event_loop::run_until_done(task<T>&)`](src/rpp/event_loop.h#L333) or [`run_until_done(deferred<T>&)`](src/rpp/event_loop.h#L362).
 
 Example: [tests/test_task.cpp](tests/test_task.cpp)
 
@@ -1519,18 +1517,18 @@ C++20 coroutine awaiters and `co_await` operators. Supports MSVC++, GCC, and Cla
 
 | Class | Description |
 |-------|-------------|
-| [`functor_awaiter<T>`](src/rpp/coroutines.h#L34) | Awaiter for lambdas/delegates via `parallel_task()` |
-| [`functor_awaiter_fut<F>`](src/rpp/coroutines.h#L116) | Awaiter for lambdas returning futures |
-| [`time_awaiter`](src/rpp/coroutines.h#L196) | Awaiter for `rpp::Duration` durations (async sleep) |
+| [`functor_awaiter<T>`](src/rpp/coroutines.h#L33) | Awaiter for lambdas/delegates via `parallel_task()` |
+| [`functor_awaiter_fut<F>`](src/rpp/coroutines.h#L115) | Awaiter for lambdas returning futures |
+| [`time_awaiter`](src/rpp/coroutines.h#L195) | Awaiter for `rpp::Duration` durations (async sleep) |
 
 ### co_await Operators (namespace `coro_operators`)
 
 | Operator | Description |
 |----------|-------------|
-| [`operator co_await(delegate<T()>&&)`](src/rpp/coroutines.h#L249) | Run delegate async on thread pool |
-| [`operator co_await(lambda&&)`](src/rpp/coroutines.h#L280) | Run lambda async on thread pool |
-| [`operator co_await(cfuture<T>&)`](src/rpp/coroutines.h#L286) | Await a composable future |
-| [`operator co_await(rpp::Duration)`](src/rpp/coroutines.h#L316) | Async sleep for a duration |
+| [`operator co_await(delegate<T()>&&)`](src/rpp/coroutines.h#L248) | Run delegate async on thread pool |
+| [`operator co_await(lambda&&)`](src/rpp/coroutines.h#L279) | Run lambda async on thread pool |
+| [`operator co_await(cfuture<T>&)`](src/rpp/coroutines.h#L285) | Await a composable future |
+| [`operator co_await(rpp::Duration)`](src/rpp/coroutines.h#L315) | Async sleep for a duration |
 
 ```cpp
 using namespace rpp::coro_operators;
@@ -1551,48 +1549,48 @@ Single-threaded event loop that serializes coroutine completions. Unlike `thread
 
 | Class | Description |
 |-------|-------------|
-| [`event_loop`](src/rpp/event_loop.h#L144) | Main event loop class with `run_loop()`, `run_once()`, `run_until_idle()`, `run_until_done(task)` |
-| [`event_task`](src/rpp/event_loop.h#L54) | Lightweight top-level coroutine return type for event-loop-driven coroutines |
+| [`event_loop`](src/rpp/event_loop.h#L143) | Main event loop class with `run_loop()`, `run_once()`, `run_until_idle()`, `run_until_done(task)` |
+| [`event_task`](src/rpp/event_loop.h#L53) | Lightweight top-level coroutine return type for event-loop-driven coroutines |
 
 ### event_loop Methods
 
 | Method | Description |
 |--------|-------------|
-| [`run_loop()`](src/rpp/event_loop.h#L296) | Run the loop until `stop()` is called, then drain remaining work |
-| [`run_once(Duration timeout)`](src/rpp/event_loop.h#L305) | Process at most one pending resume event; `Duration::zero()` for non-blocking poll |
-| [`run_until_idle()`](src/rpp/event_loop.h#L322) | Run until no background tasks and no pending resume events remain |
-| [`run_until_done(event_task& task)`](src/rpp/event_loop.h#L334) | Drive the loop until the given `event_task` completes, then rethrow on failure |
-| [`run_until_done(task<T>& task)`](src/rpp/event_loop.h#L352) | Pump the loop until the eager `rpp::task<T>` completes; returns its value (or rethrows) |
-| [`pump_until_ready(cfuture<T>&, timeout)`](src/rpp/event_loop.h#L382) | Pump on the owner thread until that one future is ready; `bool`, never blocks past timeout |
-| [`run_until_ready(cfuture<T>&, timeout)`](src/rpp/event_loop.h#L400) | Pump until that future is ready, then return its value; throws on timeout |
-| [`ensure_on_owner_thread(source_location)`](src/rpp/event_loop.h#L413) | Debug check: true if on the loop's owner thread, else logs an error at the call site |
-| [`run_async(Func&& fut_or_cb)`](src/rpp/event_loop.h#L718) | Dispatch future or lambda to thread pool, resume coroutine on the loop thread |
-| [`fork(Func&& coro_factory)`](src/rpp/event_loop.h#L442) | Fork a concurrent coroutine path (fire-and-forget, tracked internally) |
-| [`join_forks(Duration timeout)`](src/rpp/event_loop.h#L917) | Event-driven join: suspend until all forks complete or timeout expires |
-| [`num_forks()`](src/rpp/event_loop.h#L486) | Number of active forked coroutines |
-| [`drain_forks()`](src/rpp/event_loop.h#L494) | Check completed forks for exceptions and clear them |
-| [`await(semaphore&, Duration)`](src/rpp/event_loop.h#L749) | Wait for semaphore signal, resume on loop thread |
-| [`await(concurrent_queue<T>&, T&, Duration)`](src/rpp/event_loop.h#L763) | Pop from queue, resume on loop thread |
-| [`await_pop(concurrent_queue<T>&, Duration)`](src/rpp/event_loop.h#L777) | Pop from queue returning `optional<T>`, resume on loop thread |
-| [`post(delegate<void()> callback)`](src/rpp/event_loop.h#L543) | Post a callback to execute on the loop thread (like `run_on_main_thread`) |
-| [`post_resume(coro_handle<> handle)`](src/rpp/event_loop.h#L535) | Post a raw coroutine handle resume to the loop thread |
-| [`resume_on_loop()`](src/rpp/event_loop.h#L932) | `co_await` to unconditionally reschedule the current coroutine onto the loop thread |
-| [`delay(Duration duration)`](src/rpp/event_loop.h#L826) | Sleep on a background thread, resume on the loop thread |
-| [`delay_until(TimePoint until)`](src/rpp/event_loop.h#L830) | Sleep until a time point, resume on the loop thread |
-| [`stop()`](src/rpp/event_loop.h#L248) | Signal the loop to stop and finalize pending tasks |
-| [`wait_on_all(Duration timeout)`](src/rpp/event_loop.h#L255) | Block until all pending work drains, with timeout |
-| [`set_except_handler(handler)`](src/rpp/event_loop.h#L261) | Set custom exception handler for unhandled background errors |
-| [`has_pending_work()`](src/rpp/event_loop.h#L240) | True if any background tasks or resume events are pending |
-| [`background_tasks()`](src/rpp/event_loop.h#L231) | Number of tasks currently suspended in background work |
-| [`pending_completions()`](src/rpp/event_loop.h#L237) | Number of pending resume events queued for the loop thread |
-| [`main_thread_id()`](src/rpp/event_loop.h#L243) | Thread ID of the loop's owner thread |
+| [`run_loop()`](src/rpp/event_loop.h#L295) | Run the loop until `stop()` is called, then drain remaining work |
+| [`run_once(Duration timeout)`](src/rpp/event_loop.h#L304) | Process at most one pending resume event; `Duration::zero()` for non-blocking poll |
+| [`run_until_idle()`](src/rpp/event_loop.h#L321) | Run until no background tasks and no pending resume events remain |
+| [`run_until_done(event_task& task)`](src/rpp/event_loop.h#L333) | Drive the loop until the given `event_task` completes, then rethrow on failure |
+| [`run_until_done(task<T>& task)`](src/rpp/event_loop.h#L351) | Pump the loop until the eager `rpp::task<T>` completes; returns its value (or rethrows) |
+| [`pump_until_ready(cfuture<T>&, timeout)`](src/rpp/event_loop.h#L381) | Pump on the owner thread until that one future is ready; `bool`, never blocks past timeout |
+| [`run_until_ready(cfuture<T>&, timeout)`](src/rpp/event_loop.h#L399) | Pump until that future is ready, then return its value; throws on timeout |
+| [`ensure_on_owner_thread(source_location)`](src/rpp/event_loop.h#L412) | Debug check: true if on the loop's owner thread, else logs an error at the call site |
+| [`run_async(Func&& fut_or_cb)`](src/rpp/event_loop.h#L717) | Dispatch future or lambda to thread pool, resume coroutine on the loop thread |
+| [`fork(Func&& coro_factory)`](src/rpp/event_loop.h#L441) | Fork a concurrent coroutine path (fire-and-forget, tracked internally) |
+| [`join_forks(Duration timeout)`](src/rpp/event_loop.h#L916) | Event-driven join: suspend until all forks complete or timeout expires |
+| [`num_forks()`](src/rpp/event_loop.h#L485) | Number of active forked coroutines |
+| [`drain_forks()`](src/rpp/event_loop.h#L493) | Check completed forks for exceptions and clear them |
+| [`await(semaphore&, Duration)`](src/rpp/event_loop.h#L748) | Wait for semaphore signal, resume on loop thread |
+| [`await(concurrent_queue<T>&, T&, Duration)`](src/rpp/event_loop.h#L762) | Pop from queue, resume on loop thread |
+| [`await_pop(concurrent_queue<T>&, Duration)`](src/rpp/event_loop.h#L776) | Pop from queue returning `optional<T>`, resume on loop thread |
+| [`post(delegate<void()> callback)`](src/rpp/event_loop.h#L542) | Post a callback to execute on the loop thread (like `run_on_main_thread`) |
+| [`post_resume(coro_handle<> handle)`](src/rpp/event_loop.h#L534) | Post a raw coroutine handle resume to the loop thread |
+| [`resume_on_loop()`](src/rpp/event_loop.h#L931) | `co_await` to unconditionally reschedule the current coroutine onto the loop thread |
+| [`delay(Duration duration)`](src/rpp/event_loop.h#L825) | Sleep on a background thread, resume on the loop thread |
+| [`delay_until(TimePoint until)`](src/rpp/event_loop.h#L829) | Sleep until a time point, resume on the loop thread |
+| [`stop()`](src/rpp/event_loop.h#L247) | Signal the loop to stop and finalize pending tasks |
+| [`wait_on_all(Duration timeout)`](src/rpp/event_loop.h#L254) | Block until all pending work drains, with timeout |
+| [`set_except_handler(handler)`](src/rpp/event_loop.h#L260) | Set custom exception handler for unhandled background errors |
+| [`has_pending_work()`](src/rpp/event_loop.h#L239) | True if any background tasks or resume events are pending |
+| [`background_tasks()`](src/rpp/event_loop.h#L230) | Number of tasks currently suspended in background work |
+| [`pending_completions()`](src/rpp/event_loop.h#L236) | Number of pending resume events queued for the loop thread |
+| [`main_thread_id()`](src/rpp/event_loop.h#L242) | Thread ID of the loop's owner thread |
 
 ### event_task Methods
 
 | Method | Description |
 |--------|-------------|
-| [`done()`](src/rpp/event_loop.h#L95) | True if the coroutine has finished or was never started |
-| [`rethrow_if_exception()`](src/rpp/event_loop.h#L98) | Rethrow any unhandled exception captured by the coroutine |
+| [`done()`](src/rpp/event_loop.h#L94) | True if the coroutine has finished or was never started |
+| [`rethrow_if_exception()`](src/rpp/event_loop.h#L97) | Rethrow any unhandled exception captured by the coroutine |
 | `on_complete` | Optional completion callback in `promise_type`, called at `final_suspend` (used by `fork()`) |
 
 ### event_loop Example
@@ -1892,23 +1890,23 @@ Counting semaphore and lightweight notification flags.
 
 | Class | Description |
 |-------|-------------|
-| [`semaphore`](src/rpp/semaphore.h#L33) | Counting semaphore with spin-lock optimization |
-| [`semaphore_flag`](src/rpp/semaphore.h#L407) | Lighter semaphore using a single atomic flag |
-| [`semaphore_once_flag`](src/rpp/semaphore.h#L445) | One-shot semaphore that can only be set once |
+| [`semaphore`](src/rpp/semaphore.h#L29) | Counting semaphore with spin-lock optimization |
+| [`semaphore_flag`](src/rpp/semaphore.h#L401) | Lighter semaphore using a single atomic flag |
+| [`semaphore_once_flag`](src/rpp/semaphore.h#L437) | One-shot semaphore that can only be set once |
 
 ### semaphore Methods
 
 | Method | Description |
 |--------|-------------|
-| [`notify()`](src/rpp/semaphore.h#L109) | Increment and wake one waiter |
-| [`notify_all()`](src/rpp/semaphore.h#L146) | Wake all waiters |
-| [`notify_once()`](src/rpp/semaphore.h#L181) | Notify only if not already signaled |
-| [`try_wait()`](src/rpp/semaphore.h#L221) | Non-blocking wait attempt |
-| [`wait()`](src/rpp/semaphore.h#L241) | Blocking wait |
-| [`wait(Duration timeout)`](src/rpp/semaphore.h#L276) | Wait with timeout |
-| [`await(Duration timeout)`](src/rpp/semaphore.h#L396) | C++20 coroutine `co_await` — dispatches wait to background thread |
-| [`count()`](src/rpp/semaphore.h#L72) | Current count |
-| [`reset()`](src/rpp/semaphore.h#L63) | Reset to zero |
+| [`notify()`](src/rpp/semaphore.h#L108) | Increment and wake one waiter |
+| [`notify_all()`](src/rpp/semaphore.h#L145) | Wake all waiters |
+| [`notify_once()`](src/rpp/semaphore.h#L180) | Notify only if not already signaled |
+| [`try_wait()`](src/rpp/semaphore.h#L220) | Non-blocking wait attempt |
+| [`wait()`](src/rpp/semaphore.h#L240) | Blocking wait |
+| [`wait(Duration timeout)`](src/rpp/semaphore.h#L277) | Wait with timeout |
+| [`await(Duration timeout)`](src/rpp/semaphore.h#L391) | C++20 coroutine `co_await` — dispatches wait to background thread |
+| [`count()`](src/rpp/semaphore.h#L68) | Current count |
+| [`reset()`](src/rpp/semaphore.h#L59) | Reset to zero |
 
 ### Example: Coroutine co_await
 
@@ -3614,26 +3612,26 @@ Thread-safe FIFO queue with notification support.
 
 | Class | Description |
 |-------|-------------|
-| [`concurrent_queue<T>`](src/rpp/concurrent_queue.h#L48) | Thread-safe queue with push/pop/wait |
+| [`concurrent_queue<T>`](src/rpp/concurrent_queue.h#L44) | Thread-safe queue with push/pop/wait |
 
 ### Methods
 
 | Method | Description |
 |--------|-------------|
-| [`push(T&& item)`](src/rpp/concurrent_queue.h#L317) | Push an item |
-| [`push(T&&... items)`](src/rpp/concurrent_queue.h#L317) | Push multiple items |
-| [`try_pop(T& out)`](src/rpp/concurrent_queue.h#L1022) | Non-blocking pop attempt |
-| [`try_pop_all(std::vector<T>& out)`](src/rpp/concurrent_queue.h#L301) | Pop all items at once |
-| [`wait_pop(Duration timeout)`](src/rpp/concurrent_queue.h#L541) | Blocking pop with timeout |
-| [`wait_pop(T& outItem, Duration timeout)`](src/rpp/concurrent_queue.h#L634) | Blocking pop with predicate and timeout |
-| [`clear()`](src/rpp/concurrent_queue.h#L199) | Clear the queue |
-| [`empty()`](src/rpp/concurrent_queue.h#L131) | True if empty |
-| [`size()`](src/rpp/concurrent_queue.h#L150) | Number of items |
-| [`reserve(int n)`](src/rpp/concurrent_queue.h#L231) | Reserve capacity |
-| [`notify()`](src/rpp/concurrent_queue.h#L159) / [`notify_one()`](src/rpp/concurrent_queue.h#L168) | Wake waiting consumers |
-| [`await(Duration timeout)`](src/rpp/concurrent_queue.h#L1003) | C++20 coroutine `co_await` — wait for items available |
-| [`await_pop(T& out, Duration timeout)`](src/rpp/concurrent_queue.h#L1034) | C++20 coroutine `co_await` — pop item (returns bool) |
-| [`await_pop(Duration timeout)`](src/rpp/concurrent_queue.h#L1068) | C++20 coroutine `co_await` — pop item (returns `optional<T>`) |
+| [`push(T&& item)`](src/rpp/concurrent_queue.h#L313) | Push an item |
+| [`push(T&&... items)`](src/rpp/concurrent_queue.h#L313) | Push multiple items |
+| [`try_pop(T& out)`](src/rpp/concurrent_queue.h#L1017) | Non-blocking pop attempt |
+| [`try_pop_all(std::vector<T>& out)`](src/rpp/concurrent_queue.h#L297) | Pop all items at once |
+| [`wait_pop(Duration timeout)`](src/rpp/concurrent_queue.h#L537) | Blocking pop with timeout |
+| [`wait_pop(T& outItem, Duration timeout)`](src/rpp/concurrent_queue.h#L630) | Blocking pop with predicate and timeout |
+| [`clear()`](src/rpp/concurrent_queue.h#L195) | Clear the queue |
+| [`empty()`](src/rpp/concurrent_queue.h#L127) | True if empty |
+| [`size()`](src/rpp/concurrent_queue.h#L146) | Number of items |
+| [`reserve(int n)`](src/rpp/concurrent_queue.h#L227) | Reserve capacity |
+| [`notify()`](src/rpp/concurrent_queue.h#L155) / [`notify_one()`](src/rpp/concurrent_queue.h#L164) | Wake waiting consumers |
+| [`await(Duration timeout)`](src/rpp/concurrent_queue.h#L998) | C++20 coroutine `co_await` — wait for items available |
+| [`await_pop(T& out, Duration timeout)`](src/rpp/concurrent_queue.h#L1029) | C++20 coroutine `co_await` — pop item (returns bool) |
+| [`await_pop(Duration timeout)`](src/rpp/concurrent_queue.h#L1063) | C++20 coroutine `co_await` — pop item (returns `optional<T>`) |
 
 ### Example: Coroutine co_await
 
@@ -4515,10 +4513,10 @@ adds `#include <rpp/tests.macros.h>` for them, because a module cannot export a 
 
 | Method | Description |
 |--------|-------------|
-| [`test::run_tests(strview testNamePatterns)`](src/rpp/tests.h#L271) | Run tests matching patterns |
-| [`test::run_tests(int argc, char* argv[])`](src/rpp/tests.h#L282) | Run tests from command line args |
-| [`test::run_tests()`](src/rpp/tests.h#L287) | Run all registered tests |
-| [`test::is_ci_machine()`](src/rpp/tests.h#L210) | Returns TRUE if the tests run on a CI machine, which shares its CPU time |
+| [`test::run_tests(strview testNamePatterns)`](src/rpp/tests.h#L265) | Run tests matching patterns |
+| [`test::run_tests(int argc, char* argv[])`](src/rpp/tests.h#L276) | Run tests from command line args |
+| [`test::run_tests()`](src/rpp/tests.h#L281) | Run all registered tests |
+| [`test::is_ci_machine()`](src/rpp/tests.h#L206) | Returns TRUE if the tests run on a CI machine, which shares its CPU time |
 | [`register_test(name, factory, autorun)`](src/rpp/tests.h#L47) | Registers a unit test with given name, factory and autorun flag |
 
 ### Example: Defining a Test Class with TestCase

--- a/README.md
+++ b/README.md
@@ -280,13 +280,13 @@ Platform detection, compiler macros, and base type definitions. This is the foun
 
 | Macro | Description |
 |-------|-------------|
-| [`RPP_HAS_CXX20`](src/rpp/config.h#L75) | `1` if C++20 or later is available |
-| [`RPP_HAS_CXX23`](src/rpp/config.h#L85) | `1` if C++23 or later is available |
-| [`RPP_HAS_CXX26`](src/rpp/config.h#L93) | `1` if C++26 or later is available |
+| [`RPP_HAS_CXX23`](src/rpp/config.h#L84) | `1` if C++23 or later is available |
+| [`RPP_HAS_CXX26`](src/rpp/config.h#L92) | `1` if C++26 or later is available |
 
-C++20 is the floor. The library uses `consteval`, concepts and coroutines, so no
-`RPP_HAS_CXX17` macro exists and no header carries a C++17 path. `RPP_INLINE_STATIC`
-and `RPP_CONSTEXPR_STRLEN` are gone with it. Write `inline static` and `constexpr`.
+C++20 is the floor. The library uses `consteval`, concepts and coroutines. No
+`RPP_HAS_CXX17` or `RPP_HAS_CXX20` macro exists, and no header carries a pre-C++20 path.
+A `static_assert` in `config.h` rejects a lower `-std`. `RPP_INLINE_STATIC` and
+`RPP_CONSTEXPR_STRLEN` are gone with it. Write `inline static` and `constexpr`.
 
 ### API Export / Linkage
 
@@ -300,61 +300,61 @@ and `RPP_CONSTEXPR_STRLEN` are gone with it. Write `inline static` and `constexp
 
 | Macro | Description |
 |-------|-------------|
-| [`RPP_ASAN`](src/rpp/config.h#L104) | `1` if AddressSanitizer is enabled |
-| [`RPP_TSAN`](src/rpp/config.h#L113) | `1` if ThreadSanitizer is enabled |
-| [`RPP_UBSAN`](src/rpp/config.h#L120) | `1` if UndefinedBehaviorSanitizer is enabled (Clang only) |
-| [`RPP_SANITIZERS`](src/rpp/config.h#L130) | `1` if any sanitizer (ASAN, TSAN, UBSAN) is enabled |
+| [`RPP_ASAN`](src/rpp/config.h#L103) | `1` if AddressSanitizer is enabled |
+| [`RPP_TSAN`](src/rpp/config.h#L112) | `1` if ThreadSanitizer is enabled |
+| [`RPP_UBSAN`](src/rpp/config.h#L119) | `1` if UndefinedBehaviorSanitizer is enabled (Clang only) |
+| [`RPP_SANITIZERS`](src/rpp/config.h#L129) | `1` if any sanitizer (ASAN, TSAN, UBSAN) is enabled |
 
 ### Platform & Architecture
 
 | Macro | Description |
 |-------|-------------|
-| [`RPP_BARE_METAL`](src/rpp/config.h#L184) | `1` if targeting a bare-metal/embedded platform (FreeRTOS or STM32 HAL) |
-| [`RPP_FREERTOS`](src/rpp/config.h#L170) | `1` if targeting FreeRTOS |
-| [`RPP_STM32_HAL`](src/rpp/config.h#L174) | `1` if targeting STM32 HAL (requires `RPP_STM32_HAL_H` path) |
+| [`RPP_BARE_METAL`](src/rpp/config.h#L183) | `1` if targeting a bare-metal/embedded platform (FreeRTOS or STM32 HAL) |
+| [`RPP_FREERTOS`](src/rpp/config.h#L169) | `1` if targeting FreeRTOS |
+| [`RPP_STM32_HAL`](src/rpp/config.h#L173) | `1` if targeting STM32 HAL (requires `RPP_STM32_HAL_H` path) |
 | [`RPP_ANDROID`](src/rpp/config.h#L38) | `1` if targeting Android, with any compiler |
 | [`RPP_ANDROID_CLANG`](src/rpp/config.h#L47) | `1` if targeting Android with Clang |
-| [`RPP_USE_EYALROZ_PRINTF`](src/rpp/config.h#L188) | `1` to use [eyalroz/printf](https://github.com/eyalroz/printf) (`printf_`/`snprintf_`) on bare-metal instead of standard `printf` |
-| [`RPP_CORTEX_M_ARCH`](src/rpp/config.h#L195) | `1` if targeting ARM Cortex-M architecture |
-| [`RPP_ARM_ARCH`](src/rpp/config.h#L211) | `1` if compiling for ARM (`__thumb__` or `__arm__`) |
-| [`RPP_64BIT`](src/rpp/config.h#L234) | `1` if compiling for a 64-bit target |
-| [`RPP_LITTLE_ENDIAN`](src/rpp/config.h#L379) | `1` if target is little-endian |
-| [`RPP_BIG_ENDIAN`](src/rpp/config.h#L381) | `1` if target is big-endian |
-| [`RPP_HAS_EXCEPTIONS`](src/rpp/config.h#L402) | `1` if C++ exceptions are enabled. Auto-detected via `_CPPUNWIND` (MSVC), `__EXCEPTIONS`/`__cpp_exceptions` (GCC/Clang). Defaults to `1` on unknown compilers. Can be overridden manually. |
+| [`RPP_USE_EYALROZ_PRINTF`](src/rpp/config.h#L187) | `1` to use [eyalroz/printf](https://github.com/eyalroz/printf) (`printf_`/`snprintf_`) on bare-metal instead of standard `printf` |
+| [`RPP_CORTEX_M_ARCH`](src/rpp/config.h#L194) | `1` if targeting ARM Cortex-M architecture |
+| [`RPP_ARM_ARCH`](src/rpp/config.h#L210) | `1` if compiling for ARM (`__thumb__` or `__arm__`) |
+| [`RPP_64BIT`](src/rpp/config.h#L233) | `1` if compiling for a 64-bit target |
+| [`RPP_LITTLE_ENDIAN`](src/rpp/config.h#L378) | `1` if target is little-endian |
+| [`RPP_BIG_ENDIAN`](src/rpp/config.h#L380) | `1` if target is big-endian |
+| [`RPP_HAS_EXCEPTIONS`](src/rpp/config.h#L401) | `1` if C++ exceptions are enabled. Auto-detected via `_CPPUNWIND` (MSVC), `__EXCEPTIONS`/`__cpp_exceptions` (GCC/Clang). Defaults to `1` on unknown compilers. Can be overridden manually. |
 
 ### Feature Detection
 
 | Macro | Description |
 |-------|-------------|
-| [`RPP_HAS_QT`](src/rpp/config.h#L139) | `1` if Qt framework is detected (`QT_VERSION` or `QT_CORE_LIB`) |
-| [`RPP_ENABLE_UNICODE`](src/rpp/config.h#L151) | `1` if UTF-16/wstring support is enabled (auto-detected per platform) |
-| [`RPP_WCHAR_IS_UTF32`](src/rpp/config.h#L165) | `1` if a `wchar_t` holds a whole UTF-32 code point, `0` if it holds UTF-16 (Windows) |
+| [`RPP_HAS_QT`](src/rpp/config.h#L138) | `1` if Qt framework is detected (`QT_VERSION` or `QT_CORE_LIB`) |
+| [`RPP_ENABLE_UNICODE`](src/rpp/config.h#L150) | `1` if UTF-16/wstring support is enabled (auto-detected per platform) |
+| [`RPP_WCHAR_IS_UTF32`](src/rpp/config.h#L164) | `1` if a `wchar_t` holds a whole UTF-32 code point, `0` if it holds UTF-16 (Windows) |
 
 ### Function Attributes
 
 | Macro | Description |
 |-------|-------------|
-| [`FINLINE`](src/rpp/config.h#L229) | Force inline: `__forceinline` on MSVC, `__attribute__((always_inline))` on GCC/Clang |
-| [`NOINLINE`](src/rpp/config.h#L220) | Prevent inlining: `__declspec(noinline)` on MSVC, `__attribute__((noinline))` on GCC/Clang |
-| [`NODISCARD`](src/rpp/config.h#L271) | Portable `[[nodiscard]]` with fallback to empty on older compilers |
-| [`RPP_NORETURN`](src/rpp/config.h#L325) | Portable `[[noreturn]]` / `__declspec(noreturn)` / `__attribute__((noreturn))` |
-| [`NOCOPY_NOMOVE(T)`](src/rpp/config.h#L251) | Delete copy and move constructors and assignment operators |
+| [`FINLINE`](src/rpp/config.h#L228) | Force inline: `__forceinline` on MSVC, `__attribute__((always_inline))` on GCC/Clang |
+| [`NOINLINE`](src/rpp/config.h#L219) | Prevent inlining: `__declspec(noinline)` on MSVC, `__attribute__((noinline))` on GCC/Clang |
+| [`NODISCARD`](src/rpp/config.h#L270) | Portable `[[nodiscard]]` with fallback to empty on older compilers |
+| [`RPP_NORETURN`](src/rpp/config.h#L324) | Portable `[[noreturn]]` / `__declspec(noreturn)` / `__attribute__((noreturn))` |
+| [`NOCOPY_NOMOVE(T)`](src/rpp/config.h#L250) | Delete copy and move constructors and assignment operators |
 
 ### Printf Format Validation
 
 | Macro | Description |
 |-------|-------------|
-| [`PRINTF_FMTSTR`](src/rpp/config.h#L285) | MSVC `_Printf_format_string_` annotation (empty on GCC/Clang) |
-| [`PRINTF_CHECKFMT1..8`](src/rpp/config.h#L303) | GCC/Clang `__format__(__printf__)` attribute for validating printf args at compile time. Number indicates format string argument position |
+| [`PRINTF_FMTSTR`](src/rpp/config.h#L284) | MSVC `_Printf_format_string_` annotation (empty on GCC/Clang) |
+| [`PRINTF_CHECKFMT1..8`](src/rpp/config.h#L302) | GCC/Clang `__format__(__printf__)` attribute for validating printf args at compile time. Number indicates format string argument position |
 
 ### Lifetime & Coroutine Annotations
 
 | Macro | Description |
 |-------|-------------|
-| [`RPP_LIFETIMEBOUND`](src/rpp/config.h#L341) | Annotates parameters whose lifetime must outlive the return value. `[[msvc::lifetimebound]]` / `[[clang::lifetimebound]]` |
-| [`RPP_CORO_RETURN_TYPE`](src/rpp/config.h#L354) | Marks a type as a coroutine return type (`[[clang::coro_return_type]]`) |
-| [`RPP_CORO_WRAPPER`](src/rpp/config.h#L355) | Marks a non-coroutine function that returns a CRT (`[[clang::coro_wrapper]]`) |
-| [`RPP_CORO_LIFETIMEBOUND`](src/rpp/config.h#L356) | Coroutine-specific lifetime annotation (`[[clang::coro_lifetimebound]]`) |
+| [`RPP_LIFETIMEBOUND`](src/rpp/config.h#L340) | Annotates parameters whose lifetime must outlive the return value. `[[msvc::lifetimebound]]` / `[[clang::lifetimebound]]` |
+| [`RPP_CORO_RETURN_TYPE`](src/rpp/config.h#L353) | Marks a type as a coroutine return type (`[[clang::coro_return_type]]`) |
+| [`RPP_CORO_WRAPPER`](src/rpp/config.h#L354) | Marks a non-coroutine function that returns a CRT (`[[clang::coro_wrapper]]`) |
+| [`RPP_CORO_LIFETIMEBOUND`](src/rpp/config.h#L355) | Coroutine-specific lifetime annotation (`[[clang::coro_lifetimebound]]`) |
 
 ### Integer Size Constants
 
@@ -364,14 +364,14 @@ and `RPP_CONSTEXPR_STRLEN` are gone with it. Write `inline static` and `constexp
 | [`RPP_INT_SIZE`](src/rpp/config.types.h#L11) | Size of `int` in bytes |
 | [`RPP_LONG_SIZE`](src/rpp/config.types.h#L12) | Size of `long` in bytes |
 | [`RPP_LONG_LONG_SIZE`](src/rpp/config.types.h#L13) | Size of `long long` in bytes |
-| [`RPP_INT64_MIN`](src/rpp/config.h#L362) | 64-bit signed integer limits |
-| [`RPP_INT64_MAX`](src/rpp/config.h#L361) | 64-bit signed integer limits |
-| [`RPP_UINT64_MIN`](src/rpp/config.h#L364) | 64-bit unsigned integer limits |
-| [`RPP_UINT64_MAX`](src/rpp/config.h#L363) | 64-bit unsigned integer limits |
-| [`RPP_INT32_MIN`](src/rpp/config.h#L366) | 32-bit signed integer limits |
-| [`RPP_INT32_MAX`](src/rpp/config.h#L365) | 32-bit signed integer limits |
-| [`RPP_UINT32_MIN`](src/rpp/config.h#L368) | 32-bit unsigned integer limits |
-| [`RPP_UINT32_MAX`](src/rpp/config.h#L367) | 32-bit unsigned integer limits |
+| [`RPP_INT64_MIN`](src/rpp/config.h#L361) | 64-bit signed integer limits |
+| [`RPP_INT64_MAX`](src/rpp/config.h#L360) | 64-bit signed integer limits |
+| [`RPP_UINT64_MIN`](src/rpp/config.h#L363) | 64-bit unsigned integer limits |
+| [`RPP_UINT64_MAX`](src/rpp/config.h#L362) | 64-bit unsigned integer limits |
+| [`RPP_INT32_MIN`](src/rpp/config.h#L365) | 32-bit signed integer limits |
+| [`RPP_INT32_MAX`](src/rpp/config.h#L364) | 32-bit signed integer limits |
+| [`RPP_UINT32_MIN`](src/rpp/config.h#L367) | 32-bit unsigned integer limits |
+| [`RPP_UINT32_MAX`](src/rpp/config.h#L366) | 32-bit unsigned integer limits |
 
 ### C++ Type Aliases (namespace `rpp`)
 
@@ -481,20 +481,20 @@ while (text.next(line, '\n'))
 | [`findany(const char* chars, int n)`](src/rpp/strview.h#L489) | Forward search for any of the specified chars |
 | [`rfindany(const char* chars, int n)`](src/rpp/strview.h#L498) | Reverse search for any of the specified chars |
 | [`count(char ch)`](src/rpp/strview.h#L507) | Count occurrences of a character |
-| [`indexof(char ch)`](src/rpp/strview.h#L512) | Index of character, or -1 |
+| [`indexof(char ch)`](src/rpp/strview.h#L510) | Index of character, or -1 |
 | [`rindexof(char ch)`](src/rpp/strview.h#L515) | Reverse iterating index of character |
 | [`indexofany(const char* chars, int n)`](src/rpp/strview.h#L518) | First index of any matching char |
-| [`starts_with(const char* s, int len)`](src/rpp/strview.h#L527) | True if starts with the string |
-| [`starts_withi(const char* s, int len)`](src/rpp/strview.h#L538) | Case-insensitive starts_with |
+| [`starts_with(const char* s, int len)`](src/rpp/strview.h#L524) | True if starts with the string |
+| [`starts_withi(const char* s, int len)`](src/rpp/strview.h#L535) | Case-insensitive starts_with |
 | [`ends_with(const char* s, int slen)`](src/rpp/strview.h#L546) | True if ends with the string |
 | [`ends_withi(const char* s, int slen)`](src/rpp/strview.h#L557) | Case-insensitive ends_with |
 | [`equals(const char* s, int len)`](src/rpp/strview.h#L568) | Exact equality |
 | [`equalsi(const char* s, int len)`](src/rpp/strview.h#L574) | Case-insensitive equality |
-| [`compare(const char* s, int n)`](src/rpp/strview.h#L608) | Compare to another string |
+| [`compare(const char* s, int n)`](src/rpp/strview.h#L595) | Compare to another string |
 | [`split_first(char delim)`](src/rpp/strview.h#L617) | Split into two, return the first part |
 | [`split_second(char delim)`](src/rpp/strview.h#L633) | Split into two, return the second part |
 | [`next(strview& out, char delim)`](src/rpp/strview.h#L641) | Gets next token; advances ptr to next delimiter |
-| [`next(char delim)`](src/rpp/strview.h#L667) | Returns next token directly |
+| [`next(char delim)`](src/rpp/strview.h#L664) | Returns next token directly |
 | [`next_notrim(strview& out, char delim)`](src/rpp/strview.h#L708) | Gets next token without trimming; stops on delimiter |
 | [`substr(int index, int length)`](src/rpp/strview.h#L839) | Creates a substring from index with given length |
 | [`substr(int index)`](src/rpp/strview.h#L845) | Creates a substring from index to end |
@@ -505,9 +505,9 @@ while (text.next(line, '\n'))
 | [`skip_until(char ch)`](src/rpp/strview.h#L876) | Skips until the specified char is found |
 | [`skip_after(char ch)`](src/rpp/strview.h#L900) | Skips past the specified char |
 | [`to_lower()`](src/rpp/strview.h#L924) | Modifies the referenced string to lowercase |
-| [`as_lower()`](src/rpp/strview.h#L934) | Returns a lowercase copy as std::string |
+| [`as_lower()`](src/rpp/strview.h#L929) | Returns a lowercase copy as std::string |
 | [`to_upper()`](src/rpp/strview.h#L940) | Modifies the referenced string to uppercase |
-| [`as_upper()`](src/rpp/strview.h#L950) | Returns an uppercase copy as std::string |
+| [`as_upper()`](src/rpp/strview.h#L945) | Returns an uppercase copy as std::string |
 | [`replace(char chOld, char chNew)`](src/rpp/strview.h#L959) | Replaces all occurrences of chOld with chNew |
 | [`decompose(delim, T& outFirst, Rest&... rest)`](src/rpp/strview.h#L821) | Decomposes strview into multiple typed outputs |
 
@@ -682,14 +682,14 @@ if (a < b) // true — lexicographic ordering via compare()
 | [`ends_with(const char16_t* s, int slen)`](src/rpp/strview.h#L1102) | True if ends with the string |
 | [`ends_withi(const char16_t* s, int slen)`](src/rpp/strview.h#L1113) | Case-insensitive ends_with |
 | [`equals(const char16_t* s, int length)`](src/rpp/strview.h#L1123) | Exact equality |
-| [`compare(const char16_t* s, int n)`](src/rpp/strview.h#L1153) | Compare to another string |
+| [`compare(const char16_t* s, int n)`](src/rpp/strview.h#L1140) | Compare to another string |
 | [`rfind(char16_t c)`](src/rpp/strview.h#L1159) | Reverse search for a character |
 | [`findany(const char16_t* chars, int n)`](src/rpp/strview.h#L1165) | Forward search for any of the specified chars |
 | [`rfindany(const char16_t* chars, int n)`](src/rpp/strview.h#L1174) | Reverse search for any of the specified chars |
 | [`substr(int index, int length)`](src/rpp/strview.h#L1183) | Creates a substring from index with given length |
 | [`substr(int index)`](src/rpp/strview.h#L1189) | Creates a substring from index to end |
 | [`next(ustrview& out, char16_t delim)`](src/rpp/strview.h#L1197) | Gets next token; advances ptr to next delimiter |
-| [`next(char16_t delim)`](src/rpp/strview.h#L1223) | Returns next token directly |
+| [`next(char16_t delim)`](src/rpp/strview.h#L1220) | Returns next token directly |
 | [`to_string()`](src/rpp/strview.h#L993) | Convert to `std::u16string` |
 | [`to_cstr(char16_t* buf, int max)`](src/rpp/strview.h#L1074) | Copy to null-terminated C-string buffer |
 | [`to_string(const wchar_t* wstr, int wstrlen)`](src/rpp/strview.h#L1475) | Converts a UTF-16 wide string to UTF-8, Windows only |
@@ -1373,10 +1373,10 @@ Composable futures with C++20 coroutine support. Uses `rpp/thread_pool.h` for ba
 | [`coro_handle<T>`](src/rpp/future_types.h#L18) | Alias for `std::coroutine_handle<T>` |
 | [`suspend_never`](src/rpp/future_types.h#L19) | Alias for the standard never-suspend awaiter |
 | [`suspend_always`](src/rpp/future_types.h#L20) | Alias for the standard always-suspend awaiter |
-| [`IsFuture`](src/rpp/future_types.h#L26) | Concept which matches `rpp::cfuture<T>` and `std::future<T>` |
-| [`NotFuture`](src/rpp/future_types.h#L32) | Concept which matches any type `IsFuture` rejects |
-| [`IsFunction`](src/rpp/future_types.h#L35) | Concept which matches a callable taking no argument |
-| [`IsFunctionReturningFuture`](src/rpp/future_types.h#L38) | Concept which matches a callable returning a future |
+| [`IsFuture`](src/rpp/future_types.h#L24) | Concept which matches `rpp::cfuture<T>` and `std::future<T>` |
+| [`NotFuture`](src/rpp/future_types.h#L30) | Concept which matches any type `IsFuture` rejects |
+| [`IsFunction`](src/rpp/future_types.h#L33) | Concept which matches a callable taking no argument |
+| [`IsFunctionReturningFuture`](src/rpp/future_types.h#L36) | Concept which matches a callable returning a future |
 
 ### Example: Composable Futures
 
@@ -1815,7 +1815,7 @@ Cross-platform mutex, spin locks, and synchronized value wrappers.
 | [`mutex`](src/rpp/mutex.h#L14) | Platform-specific mutex (custom on Windows/FreeRTOS, `std::mutex` on Linux/Mac) |
 | [`recursive_mutex`](src/rpp/mutex.h#L35) | Recursive mutex variant |
 | [`unlock_guard<Mutex>`](src/rpp/mutex.h#L172) | RAII unlock guard: unlocks on construction, relocks on destruction |
-| [`synchronized<T>`](src/rpp/mutex.h#L410) | Thread-safe value wrapper, accessed via `sync()` → `synchronize_guard` |
+| [`synchronized<T>`](src/rpp/mutex.h#L406) | Thread-safe value wrapper, accessed via `sync()` → `synchronize_guard` |
 
 ### Free Functions
 
@@ -1824,7 +1824,7 @@ Cross-platform mutex, spin locks, and synchronized value wrappers.
 | [`spin_lock(Mutex m)`](src/rpp/mutex.h#L196) | Spin-lock with fallback to blocking lock |
 | [`spin_lock_for(Mutex m, timeout)`](src/rpp/mutex.h#L232) | Spin-lock with timeout |
 | [`RPP_HAS_CRITICAL_SECTION_MUTEX`](src/rpp/mutex.h#L127) | Indicates platform provides native critical_section mutex |
-| [`RPP_SYNC_T`](src/rpp/mutex.h#L259) | Template constraint placeholder for SyncableType concept |
+| [`RPP_SYNC_T`](src/rpp/mutex.h#L258) | Template constraint placeholder for SyncableType concept |
 
 ### Example: Basic Mutex and Spin Lock
 
@@ -1890,23 +1890,23 @@ Counting semaphore and lightweight notification flags.
 
 | Class | Description |
 |-------|-------------|
-| [`semaphore`](src/rpp/semaphore.h#L29) | Counting semaphore with spin-lock optimization |
-| [`semaphore_flag`](src/rpp/semaphore.h#L401) | Lighter semaphore using a single atomic flag |
-| [`semaphore_once_flag`](src/rpp/semaphore.h#L437) | One-shot semaphore that can only be set once |
+| [`semaphore`](src/rpp/semaphore.h#L27) | Counting semaphore with spin-lock optimization |
+| [`semaphore_flag`](src/rpp/semaphore.h#L399) | Lighter semaphore using a single atomic flag |
+| [`semaphore_once_flag`](src/rpp/semaphore.h#L435) | One-shot semaphore that can only be set once |
 
 ### semaphore Methods
 
 | Method | Description |
 |--------|-------------|
-| [`notify()`](src/rpp/semaphore.h#L108) | Increment and wake one waiter |
+| [`notify()`](src/rpp/semaphore.h#L103) | Increment and wake one waiter |
 | [`notify_all()`](src/rpp/semaphore.h#L145) | Wake all waiters |
-| [`notify_once()`](src/rpp/semaphore.h#L180) | Notify only if not already signaled |
+| [`notify_once()`](src/rpp/semaphore.h#L175) | Notify only if not already signaled |
 | [`try_wait()`](src/rpp/semaphore.h#L220) | Non-blocking wait attempt |
 | [`wait()`](src/rpp/semaphore.h#L240) | Blocking wait |
-| [`wait(Duration timeout)`](src/rpp/semaphore.h#L277) | Wait with timeout |
-| [`await(Duration timeout)`](src/rpp/semaphore.h#L391) | C++20 coroutine `co_await` — dispatches wait to background thread |
-| [`count()`](src/rpp/semaphore.h#L68) | Current count |
-| [`reset()`](src/rpp/semaphore.h#L59) | Reset to zero |
+| [`wait(Duration timeout)`](src/rpp/semaphore.h#L275) | Wait with timeout |
+| [`await(Duration timeout)`](src/rpp/semaphore.h#L389) | C++20 coroutine `co_await` — dispatches wait to background thread |
+| [`count()`](src/rpp/semaphore.h#L66) | Current count |
+| [`reset()`](src/rpp/semaphore.h#L75) | Reset to zero |
 
 ### Example: Coroutine co_await
 
@@ -2031,52 +2031,52 @@ Full cross-platform TCP/UDP socket wrapper with IPv4/IPv6 support.
 
 | Enum | Description |
 |------|-------------|
-| [`address_family`](src/rpp/sockets.h#L21) | `AF_DontCare`, `AF_IPv4`, `AF_IPv6`, `AF_Bth` |
-| [`socket_type`](src/rpp/sockets.h#L29) | `ST_Stream`, `ST_Datagram`, `ST_Raw`, `ST_RDM`, `ST_SeqPacket` |
-| [`socket_category`](src/rpp/sockets.h#L39) | `SC_Unknown`, `SC_Listen`, `SC_Accept`, `SC_Client` |
-| [`ip_protocol`](src/rpp/sockets.h#L47) | `IPP_TCP`, `IPP_UDP`, `IPP_ICMP`, `IPP_BTH`, etc. |
-| [`socket_option`](src/rpp/sockets.h#L59) | `SO_None`, `SO_ReuseAddr`, `SO_Blocking`, `SO_NonBlock`, `SO_Nagle` |
+| [`address_family`](src/rpp/sockets.h#L19) | `AF_DontCare`, `AF_IPv4`, `AF_IPv6`, `AF_Bth` |
+| [`socket_type`](src/rpp/sockets.h#L27) | `ST_Stream`, `ST_Datagram`, `ST_Raw`, `ST_RDM`, `ST_SeqPacket` |
+| [`socket_category`](src/rpp/sockets.h#L37) | `SC_Unknown`, `SC_Listen`, `SC_Accept`, `SC_Client` |
+| [`ip_protocol`](src/rpp/sockets.h#L45) | `IPP_TCP`, `IPP_UDP`, `IPP_ICMP`, `IPP_BTH`, etc. |
+| [`socket_option`](src/rpp/sockets.h#L57) | `SO_None`, `SO_ReuseAddr`, `SO_Blocking`, `SO_NonBlock`, `SO_Nagle` |
 
 ### Classes
 
 | Class | Description |
 |-------|-------------|
-| [`raw_address`](src/rpp/sockets.h#L101) | IP address without port (IPv4/IPv6) |
-| [`ipaddress`](src/rpp/sockets.h#L213) | IP address + port, constructible from `"ip:port"` strings |
-| [`ipaddress4`](src/rpp/sockets.h#L367) | IPv4 convenience wrapper |
-| [`ipaddress6`](src/rpp/sockets.h#L402) | IPv6 convenience wrapper |
-| [`ipinterface`](src/rpp/sockets.h#L434) | Network interface info (name, addr, netmask, broadcast, gateway) |
-| [`socket`](src/rpp/sockets.h#L479) | Full TCP/UDP socket with send, recv, select, etc. |
+| [`raw_address`](src/rpp/sockets.h#L99) | IP address without port (IPv4/IPv6) |
+| [`ipaddress`](src/rpp/sockets.h#L211) | IP address + port, constructible from `"ip:port"` strings |
+| [`ipaddress4`](src/rpp/sockets.h#L365) | IPv4 convenience wrapper |
+| [`ipaddress6`](src/rpp/sockets.h#L400) | IPv6 convenience wrapper |
+| [`ipinterface`](src/rpp/sockets.h#L432) | Network interface info (name, addr, netmask, broadcast, gateway) |
+| [`socket`](src/rpp/sockets.h#L477) | Full TCP/UDP socket with send, recv, select, etc. |
 
 ### socket Methods
 
 | Method | Description |
 |--------|-------------|
-| [`close()`](src/rpp/sockets.h#L556) | Close the socket |
-| [`send(const void* data, int numBytes)`](src/rpp/sockets.h#L667) | Send data |
-| [`recv(void* buf, int maxBytes)`](src/rpp/sockets.h#L791) | Receive data |
-| [`sendto(const ipaddress& addr, const void* data, int numBytes)`](src/rpp/sockets.h#L703) | UDP send to address |
-| [`recvfrom(ipaddress& addr, void* buf, int maxBytes)`](src/rpp/sockets.h#L821) | UDP receive with source address |
-| [`flush()`](src/rpp/sockets.h#L741) | Flush pending data |
-| [`peek(void* buf, int maxBytes)`](src/rpp/sockets.h#L814) | Peek at incoming data without consuming |
-| [`skip(int bytes)`](src/rpp/sockets.h#L764) | Skip incoming bytes |
-| [`available()`](src/rpp/sockets.h#L775) | Bytes available to read |
-| [`select(int millis)`](src/rpp/sockets.h#L1166) | Wait for socket readability |
-| [`good()`](src/rpp/sockets.h#L575) / [`bad()`](src/rpp/sockets.h#L577) | Socket state |
-| [`set_nagle(bool enable)`](src/rpp/sockets.h#L1015) | Enable/disable Nagle's algorithm |
+| [`close()`](src/rpp/sockets.h#L554) | Close the socket |
+| [`send(const void* data, int numBytes)`](src/rpp/sockets.h#L665) | Send data |
+| [`recv(void* buf, int maxBytes)`](src/rpp/sockets.h#L785) | Receive data |
+| [`sendto(const ipaddress& addr, const void* data, int numBytes)`](src/rpp/sockets.h#L699) | UDP send to address |
+| [`recvfrom(ipaddress& addr, void* buf, int maxBytes)`](src/rpp/sockets.h#L815) | UDP receive with source address |
+| [`flush()`](src/rpp/sockets.h#L735) | Flush pending data |
+| [`peek(void* buf, int maxBytes)`](src/rpp/sockets.h#L808) | Peek at incoming data without consuming |
+| [`skip(int bytes)`](src/rpp/sockets.h#L758) | Skip incoming bytes |
+| [`available()`](src/rpp/sockets.h#L769) | Bytes available to read |
+| [`select(int millis)`](src/rpp/sockets.h#L1160) | Wait for socket readability |
+| [`good()`](src/rpp/sockets.h#L573) / [`bad()`](src/rpp/sockets.h#L575) | Socket state |
+| [`set_nagle(bool enable)`](src/rpp/sockets.h#L1012) | Enable/disable Nagle's algorithm |
 
 ### socket Static Methods
 
 | Method | Description |
 |--------|-------------|
-| [`socket::listen(localAddr, ipp, opt)`](src/rpp/sockets.h#L1259) | Create a listening server socket |
-| [`socket::listen_to(localAddr, ipp, opt)`](src/rpp/sockets.h#L1268) | Create a listening server socket |
-| [`socket::accept(timeoutMillis)`](src/rpp/sockets.h#L1312) | Accept an incoming connection |
-| [`socket::connect(remoteAddr, opt)`](src/rpp/sockets.h#L1320) | Connect to an address |
-| [`socket::connect_to(remoteAddr, opt)`](src/rpp/sockets.h#L1343) | Connect by hostname and port |
-| [`protocol_info`](src/rpp/sockets.h#L86) | Describes socket protocol version, address family, type and protocol |
-| [`make_udp_randomport(opt, bind_address)`](src/rpp/sockets.h#L1382) | Creates an INADDR_ANY UDP socket bound to a random port |
-| [`make_tcp_randomport(opt, bind_address)`](src/rpp/sockets.h#L1388) | Creates an INADDR_ANY TCP listener bound to a random port |
+| [`socket::listen(localAddr, ipp, opt)`](src/rpp/sockets.h#L1246) | Create a listening server socket |
+| [`socket::listen_to(localAddr, ipp, opt)`](src/rpp/sockets.h#L1255) | Create a listening server socket |
+| [`socket::accept(timeoutMillis)`](src/rpp/sockets.h#L1299) | Accept an incoming connection |
+| [`socket::connect(remoteAddr, opt)`](src/rpp/sockets.h#L1307) | Connect to an address |
+| [`socket::connect_to(remoteAddr, opt)`](src/rpp/sockets.h#L1330) | Connect by hostname and port |
+| [`protocol_info`](src/rpp/sockets.h#L84) | Describes socket protocol version, address family, type and protocol |
+| [`make_udp_randomport(opt, bind_address)`](src/rpp/sockets.h#L1369) | Creates an INADDR_ANY UDP socket bound to a random port |
+| [`make_tcp_randomport(opt, bind_address)`](src/rpp/sockets.h#L1375) | Creates an INADDR_ANY TCP listener bound to a random port |
 
 ### Example: IP Addresses
 
@@ -3612,26 +3612,26 @@ Thread-safe FIFO queue with notification support.
 
 | Class | Description |
 |-------|-------------|
-| [`concurrent_queue<T>`](src/rpp/concurrent_queue.h#L44) | Thread-safe queue with push/pop/wait |
+| [`concurrent_queue<T>`](src/rpp/concurrent_queue.h#L42) | Thread-safe queue with push/pop/wait |
 
 ### Methods
 
 | Method | Description |
 |--------|-------------|
-| [`push(T&& item)`](src/rpp/concurrent_queue.h#L313) | Push an item |
-| [`push(T&&... items)`](src/rpp/concurrent_queue.h#L313) | Push multiple items |
-| [`try_pop(T& out)`](src/rpp/concurrent_queue.h#L1017) | Non-blocking pop attempt |
-| [`try_pop_all(std::vector<T>& out)`](src/rpp/concurrent_queue.h#L297) | Pop all items at once |
-| [`wait_pop(Duration timeout)`](src/rpp/concurrent_queue.h#L537) | Blocking pop with timeout |
-| [`wait_pop(T& outItem, Duration timeout)`](src/rpp/concurrent_queue.h#L630) | Blocking pop with predicate and timeout |
-| [`clear()`](src/rpp/concurrent_queue.h#L195) | Clear the queue |
-| [`empty()`](src/rpp/concurrent_queue.h#L127) | True if empty |
-| [`size()`](src/rpp/concurrent_queue.h#L146) | Number of items |
-| [`reserve(int n)`](src/rpp/concurrent_queue.h#L227) | Reserve capacity |
-| [`notify()`](src/rpp/concurrent_queue.h#L155) / [`notify_one()`](src/rpp/concurrent_queue.h#L164) | Wake waiting consumers |
-| [`await(Duration timeout)`](src/rpp/concurrent_queue.h#L998) | C++20 coroutine `co_await` — wait for items available |
-| [`await_pop(T& out, Duration timeout)`](src/rpp/concurrent_queue.h#L1029) | C++20 coroutine `co_await` — pop item (returns bool) |
-| [`await_pop(Duration timeout)`](src/rpp/concurrent_queue.h#L1063) | C++20 coroutine `co_await` — pop item (returns `optional<T>`) |
+| [`push(T&& item)`](src/rpp/concurrent_queue.h#L311) | Push an item |
+| [`push(T&&... items)`](src/rpp/concurrent_queue.h#L311) | Push multiple items |
+| [`try_pop(T& out)`](src/rpp/concurrent_queue.h#L1015) | Non-blocking pop attempt |
+| [`try_pop_all(std::vector<T>& out)`](src/rpp/concurrent_queue.h#L295) | Pop all items at once |
+| [`wait_pop(Duration timeout)`](src/rpp/concurrent_queue.h#L535) | Blocking pop with timeout |
+| [`wait_pop(T& outItem, Duration timeout)`](src/rpp/concurrent_queue.h#L628) | Blocking pop with predicate and timeout |
+| [`clear()`](src/rpp/concurrent_queue.h#L193) | Clear the queue |
+| [`empty()`](src/rpp/concurrent_queue.h#L125) | True if empty |
+| [`size()`](src/rpp/concurrent_queue.h#L144) | Number of items |
+| [`reserve(int n)`](src/rpp/concurrent_queue.h#L225) | Reserve capacity |
+| [`notify()`](src/rpp/concurrent_queue.h#L153) / [`notify_one()`](src/rpp/concurrent_queue.h#L162) | Wake waiting consumers |
+| [`await(Duration timeout)`](src/rpp/concurrent_queue.h#L996) | C++20 coroutine `co_await` — wait for items available |
+| [`await_pop(T& out, Duration timeout)`](src/rpp/concurrent_queue.h#L1027) | C++20 coroutine `co_await` — pop item (returns bool) |
+| [`await_pop(Duration timeout)`](src/rpp/concurrent_queue.h#L1061) | C++20 coroutine `co_await` — pop item (returns `optional<T>`) |
 
 ### Example: Coroutine co_await
 
@@ -3951,7 +3951,7 @@ Cross-platform stack tracing and traced exceptions.
 
 | Function | Description |
 |----------|-------------|
-| [`stack_trace(maxDepth)`](src/rpp/stack_trace.h#L128) | Get formatted stack trace string |
+| [`stack_trace(maxDepth)`](src/rpp/stack_trace.h#L134) | Get formatted stack trace string |
 | [`stack_trace(message, maxDepth)`](src/rpp/stack_trace.h#L128) | Stack trace with error message |
 | [`print_trace(maxDepth)`](src/rpp/stack_trace.h#L143) | Print stack trace to stderr |
 | [`print_trace(message, maxDepth)`](src/rpp/stack_trace.h#L147) | Print stack trace to stderr with message |
@@ -4295,10 +4295,10 @@ Minimal insertion sort for smaller binary sizes compared to `std::sort`. The ins
 
 | Function | Description |
 |----------|-------------|
-| [`insertion_sort(data, count, comparison)`](src/rpp/sort.h#L59) | In-place insertion sort with comparator |
-| [`insertion_sort(container, comparison)`](src/rpp/sort.h#L82) | Sorts any contiguous container with a comparator |
-| [`sort(container)`](src/rpp/sort.h#L97) | Sorts any contiguous container in ascending order |
-| [`sort(container, comparison)`](src/rpp/sort.h#L112) | Sorts any contiguous container with a comparator |
+| [`insertion_sort(data, count, comparison)`](src/rpp/sort.h#L54) | In-place insertion sort with comparator |
+| [`insertion_sort(container, comparison)`](src/rpp/sort.h#L75) | Sorts any contiguous container with a comparator |
+| [`sort(container)`](src/rpp/sort.h#L88) | Sorts any contiguous container in ascending order |
+| [`sort(container, comparison)`](src/rpp/sort.h#L101) | Sorts any contiguous container with a comparator |
 
 A contiguous container has `data()`, `size()` and `operator[]`, which `std::vector` and
 `rpp::element_range` both answer. `collections.h` adds two more overloads. One takes an

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -527,7 +527,7 @@ Cross-referencing every `#define` against README gives:
 
 | Header | Public macros | What they are |
 |---|---|---|
-| `config.h` | **51** | `RPPAPI`, `FINLINE`, `NOINLINE`, `NODISCARD`, `RPP_ENABLE_UNICODE`, `RPP_HAS_CXX20`, and the platform probes |
+| `config.h` | **51** | `RPPAPI`, `FINLINE`, `NOINLINE`, `NODISCARD`, `RPP_ENABLE_UNICODE`, `RPP_HAS_CXX23`, and the platform probes |
 | `tests.h` | **10** | `TestImpl`, `TestCase`, `TestInit`, `AssertThat`, `AssertEqual`, `AssertThrows`, ... |
 | `endian.h` | **9** | `RPP_BYTESWAP16/32/64`, `RPP_TO_BIG*`, `RPP_TO_LITTLE*` |
 | `debugging.h` | **4** | `LogInfo`, `LogWarning`, `LogError`, `Assert` |

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -73,7 +73,7 @@ configuration became an unguarded export. Each rule carries a selftest.
 | Rule | Reaches | Mechanism |
 |---|---|---|
 | a macro a define can toggle | `RPP_ENABLE_UNICODE`, `!RPP_BARE_METAL` | parse each configuration, union the names, guard the difference |
-| a macro no define reaches | `RPP_HAS_COROUTINES` | read the `#if` span the header brackets, and match a declaration by line |
+| a macro no define reaches | none today, `RPP_HAS_COROUTINES` until it went | read the `#if` span the header brackets, and match a declaration by line |
 | an inline namespace | `rpp::literals`, `rpp::duration_literals` | read the `inline` keyword from the header |
 
 The second rule matches by declaration location, not by name text. A text search also
@@ -531,7 +531,6 @@ Cross-referencing every `#define` against README gives:
 | `tests.h` | **10** | `TestImpl`, `TestCase`, `TestInit`, `AssertThat`, `AssertEqual`, `AssertThrows`, ... |
 | `endian.h` | **9** | `RPP_BYTESWAP16/32/64`, `RPP_TO_BIG*`, `RPP_TO_LITTLE*` |
 | `debugging.h` | **4** | `LogInfo`, `LogWarning`, `LogError`, `Assert` |
-| `future_types.h` | 2 | `RPP_CORO_STD`, `RPP_HAS_COROUTINES` |
 | `mutex.h` | 2 | `RPP_HAS_CRITICAL_SECTION_MUTEX`, `RPP_SYNC_T` |
 | `close_sync.h`, `minmax.h`, `scope_guard.h` | 1 each | `try_lock_or_return`, `RPP_SSE_INTRINSICS`, `scope_guard` |
 
@@ -610,9 +609,9 @@ import rpp.tests;               // rpp::test and the rest of the framework
 ```
 
 `tests.macros.h` declares nothing, and it includes five headers. `RPP_SOURCE_LOC_CURRENT`
-and `RPP_HAS_COROUTINES` are macros, so no import can carry them, and `source_loc.h` and
-`future_types.h` bring them. `<memory>`, `<typeinfo>` and `<exception>` carry the three
-std names the macros expand to. Every other name comes from `import rpp.tests`, and macro
+is a macro, so no import can carry it, and `source_loc.h` brings it. `future_types.h`
+brings `rpp::coro_handle`, which `TestCaseCoro` expands to. `<memory>`, `<typeinfo>` and
+`<exception>` carry the three std names the macros expand to. Every other name comes from `import rpp.tests`, and macro
 expansion happens later, at the use site.
 
 `tests/module_consumer/tests_module_only.cpp` writes a suite from that pair alone, with no

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -947,7 +947,7 @@ Then port one real consumer. `krattcam` and `krattlink` both pull ReCpp through
 | 2 | add the rpp-header include check | 0.5 | changeset 3 | done |
 | 3 | generate the export lists | 1.5 | changeset 5 | done |
 | 4 | dual-mode test harness | 0.5 | changeset 5 | done, the generator --check is the gate |
-| 5 | 44 modules plus the umbrella | 2.5 | changeset 6 | 44 of 44 written |
+| 5 | 44 modules plus the umbrella | 2.5 | changeset 6 | 44 of 44 modules, umbrella remains |
 | 6 | mama and CMake packaging, consumer example | 1.5 | changeset 7 | mama done, PR #65 |
 | 7 | CI, docs, measurement | 0.5 | none | gates done |
 

--- a/docs/MODULES_MIGRATION.md
+++ b/docs/MODULES_MIGRATION.md
@@ -1,9 +1,9 @@
 # ReCpp C++20 Modules Migration Plan
 
-Revision 16. Forty-three modules exist: all of L0 to L7. Only `rpp.tests` re-exports another.
+Revision 17. Forty-four modules exist: all of L0 to L8. Only `rpp.tests` re-exports another.
 
 This document explains the pattern, records what real builds prove about it, and
-gives the phased plan for the remaining 1 header.
+gives the phased plan for the umbrella, which is all that remains.
 
 ## Handover state
 
@@ -12,36 +12,36 @@ gate, #65 changeset 6.
 
 | Item | State |
 |---|---|
-| the forty-three modules | build and pass on gcc-14, and CI covers clang-21 and MSVC 14.52 |
+| the forty-four modules | build and pass on gcc-14, and CI covers clang-21 and MSVC 14.52 |
 | `debugging.macros.h` | split out, 50 preprocessed lines against 32893 |
 | `BUILD_WITH_MODULES=AUTO` | on per toolchain, GCC 14 / Clang 21 / MSVC 19.34 |
 | Include-order style rule | in AGENTS.md, and the `import-order` gate holds it |
 | `tools/check_includes.py` | 6 checks. 4 gate CI, and `missing` and `unused` stay ungated |
-| `tests/test_modules.cpp` | module consumer test, 40 cases. It includes `tests.h` and the macro header only, so what those two mask needs a module-only target |
+| `tests/test_modules.cpp` | module consumer test, 41 cases. It includes `tests.h` and the macro header only, so what those two mask needs a module-only target |
 | `tests/module_consumer/` | a real mama consumer, on gcc, clang and MSVC, with 6 module-only targets |
 | mama | 0.14.0 exports the `.cppm` files and strips the module objects |
 | CI | 28 jobs on GitHub Actions, and CircleCI is gone |
-| test counts | 578/578 on the modules build, 538/538 on the header build |
+| test counts | 579/579 on the modules build, 538/538 on the header build |
 
 **Changeset state:** 1a is dropped, see section 4. 1b, 2, 3 and the mama half of
-6 landed. The generator drives all forty-three modules. 4 is done through the generator
-`--check`. 5 has L0 to L7 finished. Section 11 lists what 7 owes.
+6 landed. The generator drives all forty-four modules. 4 is done through the generator
+`--check`. 5 has L0 to L8 finished. Section 11 lists what 7 owes.
 
-**Next:** changeset 5, the L8 layer and the umbrella. Section 9 has the layers.
+**Next:** changeset 5, the umbrella. Section 9 has the layers.
 
 **A module re-exports nothing, and two headers ship with a workaround.** The generator
 carries `NO_EXPORT` with three entries and `RE_EXPORT` with one, and `BUGS.md` **B8** names
 the four shapes gcc-14 breaks. Shapes 2 and 3 both need a re-export, so neither can fire on
 one library-wide entry. Shape 4 lives in `binary_stream.h`, whose destructor moved out of
 line. The other two `NO_EXPORT` entries are internal names, a CRTP mixin and a unit-test
-friend, and no gcc defect drives them. `NO_CONFIG` names the five headers which do not
+friend, and no gcc defect drives them. `NO_CONFIG` names the six headers which do not
 compile on bare metal, see **B15**. The generator selftest still pins all three knobs.
 
 **gcc-14 cannot compile `std::promise` in an importer, and six modules carried that before
 L7.** Any module whose global module fragment includes `<future>` breaks such a consumer,
 and `rpp.task` alone reproduces it. No export list changes the crash, so the L7 tests name
 the `future.h` factories in an unevaluated context. **B16** holds the reproducer and the
-list of ten headers which reach `<future>`. `coroutines.h` is one, so L8 inherits the limit.
+list of ten headers which reach `<future>`. Nine of them ship as a module now.
 
 **An importer which includes `<string>` first reads a different module.** `rpp.file_io`
 passed every gate and still broke that consumer, so `std_string_module_only.cpp` holds the
@@ -813,12 +813,12 @@ between layers.
 | L5 | **binary_stream** ✓, **concurrent_queue** ✓, **semaphore** ✓ | 3 |
 | L6 | **binary_serializer** ✓, **thread_pool** ✓ | 2 |
 | L7 | **event_loop** ✓, **future** ✓ | 2 |
-| L8 | coroutines | 1 |
+| L8 | **coroutines** ✓ | 1 |
 | top | umbrella `rpp` | 1 |
 
-Every L7 module ships. `BUILD_WITH_MODULES` builds all forty-three.
+Every L8 module ships. `BUILD_WITH_MODULES` builds all forty-four.
 
-44 modules and one umbrella. L0 to L7 exist, so 1 remains. Excluded: `config.h`
+44 modules and one umbrella. L0 to L8 exist, so only the umbrella remains. Excluded: `config.h`
 and `log_colors.h` by rule 1 of section 6.3, and `jni_cpp.h` because it is
 Android glue. `tests.h` is in, and it is the one header whose macros split into
 `tests.macros.h`.
@@ -947,7 +947,7 @@ Then port one real consumer. `krattcam` and `krattlink` both pull ReCpp through
 | 2 | add the rpp-header include check | 0.5 | changeset 3 | done |
 | 3 | generate the export lists | 1.5 | changeset 5 | done |
 | 4 | dual-mode test harness | 0.5 | changeset 5 | done, the generator --check is the gate |
-| 5 | 44 modules plus the umbrella | 2.5 | changeset 6 | 43 of 44 written |
+| 5 | 44 modules plus the umbrella | 2.5 | changeset 6 | 44 of 44 written |
 | 6 | mama and CMake packaging, consumer example | 1.5 | changeset 7 | mama done, PR #65 |
 | 7 | CI, docs, measurement | 0.5 | none | gates done |
 

--- a/src/rpp/concurrent_queue.h
+++ b/src/rpp/concurrent_queue.h
@@ -19,18 +19,14 @@
 #include <malloc.h> // malloc, free
 
 #if RPP_HAS_CXX20
-#  include "future_types.h" // RPP_HAS_COROUTINES, rpp::coro_handle
-#  if RPP_HAS_COROUTINES
+#  include "future_types.h" // rpp::coro_handle
 #    include "delegate.h" // rpp::delegate (for coroutine awaiter)
-#  endif
 #endif
 
 namespace rpp
 {
-    #if RPP_HAS_COROUTINES
         // forward declaration: avoids circular include with thread_pool.h
         void parallel_task_detached(rpp::delegate<void()>&& genericTask) noexcept;
-    #endif
 
     /**
      * Provides a simple thread-safe queue with several synchronization helpers
@@ -972,7 +968,6 @@ namespace rpp
         }
 
     public:
-#if RPP_HAS_COROUTINES
         /**
          * @brief Awaitable handle for co_await on queue availability.
          * Dispatches a blocking wait to a background thread and resumes the coroutine.
@@ -1066,6 +1061,5 @@ namespace rpp
             std::optional<T> await_resume() noexcept { return std::move(result); }
         };
         RPP_CORO_WRAPPER co_pop_optional_handle await_pop(rpp::Duration timeout) noexcept { return { *this, timeout, std::nullopt }; }
-#endif
     };
 }

--- a/src/rpp/concurrent_queue.h
+++ b/src/rpp/concurrent_queue.h
@@ -18,10 +18,8 @@
 #include <cstring> // memmove
 #include <malloc.h> // malloc, free
 
-#if RPP_HAS_CXX20
-#  include "future_types.h" // rpp::coro_handle
-#    include "delegate.h" // rpp::delegate (for coroutine awaiter)
-#endif
+#include "future_types.h" // rpp::coro_handle
+#include "delegate.h" // rpp::delegate (for coroutine awaiter)
 
 namespace rpp
 {

--- a/src/rpp/config.h
+++ b/src/rpp/config.h
@@ -70,14 +70,13 @@
 #  define RPPCAPI RPP_EXTERNC RPPAPI
 #endif
 
+// C++20 is the floor, so a wrong -std stops here instead of deep inside a header
 #if __cplusplus
 #  if _MSC_VER
-#    define RPP_HAS_CXX20 (_MSVC_LANG >= 202002L)
+   static_assert(_MSVC_LANG >= 202002L, "ReCpp requires C++20 or higher");
 #  else
-#    define RPP_HAS_CXX20 (__cplusplus >= 202002L)
+   static_assert(__cplusplus >= 202002L, "ReCpp requires C++20 or higher");
 #  endif
-   // C++20 is the floor, so a wrong -std stops here instead of deep inside a header
-   static_assert(RPP_HAS_CXX20, "ReCpp requires C++20 or higher");
 #endif
 
 #if __cplusplus

--- a/src/rpp/coroutines.h
+++ b/src/rpp/coroutines.h
@@ -11,7 +11,6 @@
 #include "future_types.h" // rpp::IsFunctionNotReturningFuture
 #include "thread_pool.h" // rpp::parallel_task_detached
 
-#if RPP_HAS_COROUTINES
 
 namespace rpp
 {
@@ -57,7 +56,7 @@ namespace rpp
             // Use detached task: storing the pool_task_handle into a member is a race,
             // because cont.resume() may destroy the coroutine frame (and `this`)
             // before the handle assignment completes on the calling thread.
-            rpp::parallel_task_detached([this, cont]() /*clang-12 compat*/mutable
+            rpp::parallel_task_detached([this, cont]()
             {
                 try { result = std::move(action()); }
                 catch (...) { ex = std::current_exception(); }
@@ -96,7 +95,7 @@ namespace rpp
             // Use detached task: storing the pool_task_handle into a member is a race,
             // because cont.resume() may destroy the coroutine frame (and `this`)
             // before the handle assignment completes on the calling thread.
-            rpp::parallel_task_detached([this, cont]() /*clang-12 compat*/mutable {
+            rpp::parallel_task_detached([this, cont]() {
                 try { action(); }
                 catch (...) { ex = std::current_exception(); }
                 // WARNING: do not deallocate action here, it can lead to a race-condition + memory corruption
@@ -132,7 +131,7 @@ namespace rpp
             // Use detached task: storing the pool_task_handle into a member is a race,
             // because cont.resume() may destroy the coroutine frame (and `this`)
             // before the handle assignment completes on the calling thread.
-            rpp::parallel_task_detached([this, cont]() /*clang-12 compat*/mutable
+            rpp::parallel_task_detached([this, cont]()
             {
                 try {
                     f = action(); // get the future from the lambda
@@ -175,7 +174,7 @@ namespace rpp
             // Use detached task: storing the pool_task_handle into a member is a race,
             // because cont.resume() may destroy the coroutine frame (and `this`)
             // before the handle assignment completes on the calling thread.
-            rpp::parallel_task_detached([this, cont]() /*clang-12 compat*/mutable
+            rpp::parallel_task_detached([this, cont]()
             {
                 try { f.wait(); /* wait for the nested coroutine to finish (can throw) */ }
                 catch (...) { ex = std::current_exception(); }
@@ -205,7 +204,7 @@ namespace rpp
         }
         void await_suspend(rpp::coro_handle<> cont) const
         {
-            rpp::parallel_task_detached([cont,end=end]() /*clang-12 compat*/mutable
+            rpp::parallel_task_detached([cont,end=end]()
             {
                 rpp::sleep_until(end);
                 // resume execution while still inside the background thread
@@ -319,4 +318,3 @@ namespace rpp
         }
     }
 } // namespace rpp
-#endif // Coroutines support for C++20

--- a/src/rpp/debugging.h
+++ b/src/rpp/debugging.h
@@ -130,7 +130,7 @@ namespace rpp
         struct __wrap<std::string>
         {
             // constexpr c_str() available in C++20 and up, but not on GCC C++20
-            #if RPP_HAS_CXX23 || (RPP_HAS_CXX20 && __cpp_lib_constexpr_string && !RPP_GCC)
+            #if RPP_HAS_CXX23 || (__cpp_lib_constexpr_string && !RPP_GCC)
                 FINLINE static constexpr const char* w(const std::string& arg) noexcept { return arg.c_str(); }
             #else
                 FINLINE static const char* w(const std::string& arg) noexcept { return arg.c_str(); }

--- a/src/rpp/event_loop.cpp
+++ b/src/rpp/event_loop.cpp
@@ -5,7 +5,6 @@
  */
 #include "event_loop.h"
 
-#if RPP_HAS_COROUTINES
 
 namespace rpp
 {
@@ -307,4 +306,3 @@ namespace rpp
 
 } // namespace rpp
 
-#endif // RPP_HAS_COROUTINES

--- a/src/rpp/event_loop.h
+++ b/src/rpp/event_loop.h
@@ -27,7 +27,6 @@
 #include <stdexcept>
 #include <type_traits>
 
-#if RPP_HAS_COROUTINES
 
 namespace rpp
 {
@@ -962,4 +961,3 @@ namespace rpp
 
 } // namespace rpp
 
-#endif // RPP_HAS_COROUTINES

--- a/src/rpp/future.h
+++ b/src/rpp/future.h
@@ -512,8 +512,8 @@ namespace rpp
              * For `rpp::cfuture<T> my_coroutine() {}` this is the hidden future object
              */
             RPP_CORO_WRAPPER rpp::cfuture<T> get_return_object() noexcept { return this->get_future(); }
-            std::suspend_never initial_suspend() const noexcept { return {}; }
-            std::suspend_never final_suspend() const noexcept { return {}; }
+            rpp::suspend_never initial_suspend() const noexcept { return {}; }
+            rpp::suspend_never final_suspend() const noexcept { return {}; }
 
             // Deferred return value and exception: stored here so the future is only
             // signalled in ~promise_type(), AFTER the coroutine frame (and all its local
@@ -915,8 +915,8 @@ namespace rpp
         struct promise_type : rpp::cpromise<void>
         {
             RPP_CORO_WRAPPER rpp::cfuture<void> get_return_object() noexcept { return this->get_future(); }
-            std::suspend_never initial_suspend() const noexcept { return {}; }
-            std::suspend_never final_suspend() const noexcept { return {}; }
+            rpp::suspend_never initial_suspend() const noexcept { return {}; }
+            rpp::suspend_never final_suspend() const noexcept { return {}; }
 
             // Same deferred-signal approach as cfuture<T>::promise_type.
             std::exception_ptr deferred_ex     {};

--- a/src/rpp/future.h
+++ b/src/rpp/future.h
@@ -465,7 +465,6 @@ namespace rpp
             return true;
         }
 
-    #if RPP_HAS_COROUTINES // C++20 coro support
 
         // suspension point that launches the background async task
         void await_suspend(rpp::coro_handle<> cont) noexcept
@@ -476,7 +475,7 @@ namespace rpp
                 cont.resume();
                 return;
             }
-            rpp::parallel_task_detached([this, cont]() /*clang-12 compat:*/mutable
+            rpp::parallel_task_detached([this, cont]()
             {
                 if (this->valid())
                     this->wait();
@@ -513,8 +512,8 @@ namespace rpp
              * For `rpp::cfuture<T> my_coroutine() {}` this is the hidden future object
              */
             RPP_CORO_WRAPPER rpp::cfuture<T> get_return_object() noexcept { return this->get_future(); }
-            RPP_CORO_STD::suspend_never initial_suspend() const noexcept { return {}; }
-            RPP_CORO_STD::suspend_never final_suspend() const noexcept { return {}; }
+            std::suspend_never initial_suspend() const noexcept { return {}; }
+            std::suspend_never final_suspend() const noexcept { return {}; }
 
             // Deferred return value and exception: stored here so the future is only
             // signalled in ~promise_type(), AFTER the coroutine frame (and all its local
@@ -543,7 +542,6 @@ namespace rpp
                 else if (deferred_value) rpp::cpromise<T>::set_value(std::move(*deferred_value));
             }
         };
-    #endif // RPP_HAS_COROUTINES
     }; // cfuture<T>
 
 
@@ -875,7 +873,6 @@ namespace rpp
             return true;
         }
 
-    #if RPP_HAS_COROUTINES // C++20 coroutine support
 
         // suspension point that launches the background async task
         void await_suspend(rpp::coro_handle<> cont) noexcept
@@ -886,7 +883,7 @@ namespace rpp
                 cont.resume();
                 return;
             }
-            rpp::parallel_task_detached([this, cont]() /*clang-12 compat:*/mutable
+            rpp::parallel_task_detached([this, cont]()
             {
                 if (this->valid())
                     this->wait();
@@ -918,8 +915,8 @@ namespace rpp
         struct promise_type : rpp::cpromise<void>
         {
             RPP_CORO_WRAPPER rpp::cfuture<void> get_return_object() noexcept { return this->get_future(); }
-            RPP_CORO_STD::suspend_never initial_suspend() const noexcept { return {}; }
-            RPP_CORO_STD::suspend_never final_suspend() const noexcept { return {}; }
+            std::suspend_never initial_suspend() const noexcept { return {}; }
+            std::suspend_never final_suspend() const noexcept { return {}; }
 
             // Same deferred-signal approach as cfuture<T>::promise_type.
             std::exception_ptr deferred_ex     {};
@@ -934,7 +931,6 @@ namespace rpp
                 else if (deferred_return) rpp::cpromise<void>::set_value();
             }
         };
-    #endif // RPP_HAS_COROUTINES
     }; // cfuture<void>
 
 

--- a/src/rpp/future_types.h
+++ b/src/rpp/future_types.h
@@ -5,35 +5,8 @@
  */
 #include "config.h"
 #include <future>
-
-#if RPP_HAS_CXX20 && defined(__has_include) // Coroutines support for C++20
-    #if __has_include(<coroutine>)
-        #include <coroutine>
-        #define RPP_HAS_COROUTINES 1
-        #define RPP_CORO_STD std
-    #elif __has_include(<experimental/coroutine>) // backwards compatibility for clang-14 and older
-        #include <experimental/coroutine>
-        #define RPP_HAS_COROUTINES 1
-        #ifdef _VSTD_EXPERIMENTAL
-            #define RPP_CORO_STD _VSTD_EXPERIMENTAL
-        #else
-            #define RPP_CORO_STD std::experimental
-        #endif
-        // Clang 14 warns about std::experimental coroutines being removed in LLVM 15,
-        // suppress globally since it triggers at every co_await/co_return usage site
-        #if defined(__clang__) && defined(__has_warning)
-            #if __has_warning("-Wdeprecated-experimental-coroutine")
-                #pragma clang diagnostic ignored "-Wdeprecated-experimental-coroutine"
-            #endif
-        #endif
-    #else
-        #define RPP_HAS_COROUTINES 0
-        #define RPP_CORO_STD
-    #endif
-#else // no coroutine support for C++17 and below
-    #define RPP_HAS_COROUTINES 0
-    #define RPP_CORO_STD
-#endif
+// C++20 makes <coroutine> mandatory, freestanding included, and config.h asserts C++20
+#include <coroutine>
 
 namespace rpp
 {
@@ -41,12 +14,10 @@ namespace rpp
     class NODISCARD RPP_CORO_RETURN_TYPE RPP_CORO_LIFETIMEBOUND cfuture;
 
 
-#if RPP_HAS_COROUTINES
     template<typename T = void>
-    using coro_handle = RPP_CORO_STD::coroutine_handle<T>;
-    using suspend_never = RPP_CORO_STD::suspend_never;
-    using suspend_always = RPP_CORO_STD::suspend_always;
-#endif // RPP_HAS_COROUTINES
+    using coro_handle = std::coroutine_handle<T>;
+    using suspend_never = std::suspend_never;
+    using suspend_always = std::suspend_always;
 
 
 #if RPP_HAS_CXX20

--- a/src/rpp/future_types.h
+++ b/src/rpp/future_types.h
@@ -20,8 +20,6 @@ namespace rpp
     using suspend_always = std::suspend_always;
 
 
-#if RPP_HAS_CXX20
-
     template<typename F>
     concept IsFuture = requires(F f) {
         requires std::is_same_v<F, rpp::cfuture<decltype(f.get())>>
@@ -45,6 +43,4 @@ namespace rpp
     {
         requires IsFunction<F> && NotFuture<decltype(f())>;
     };
-
-#endif // RPP_HAS_CXX20
 }

--- a/src/rpp/mutex.h
+++ b/src/rpp/mutex.h
@@ -248,7 +248,6 @@ namespace rpp
         return std::unique_lock<Mutex>{m, std::adopt_lock};
     }
 
-#if RPP_HAS_CXX20
     template<typename T>
     concept SyncableType = requires(T t) {
         { t.get_mutex() };
@@ -257,9 +256,6 @@ namespace rpp
     // Doesn't work for some reason :shrug:
     // #define RPP_SYNC_T SyncableType
     #define RPP_SYNC_T class
-#else
-    #define RPP_SYNC_T class
-#endif
 
     template<RPP_SYNC_T SyncType>
     class synchronize_guard

--- a/src/rpp/rpp-concurrent_queue.cppm
+++ b/src/rpp/rpp-concurrent_queue.cppm
@@ -9,9 +9,7 @@ export module rpp.concurrent_queue;
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
 
 export namespace rpp {
-    using rpp::concurrent_queue;
-#if RPP_HAS_COROUTINES
     using rpp::parallel_task_detached;
-#endif
+    using rpp::concurrent_queue;
 }
 // GENERATED EXPORTS END

--- a/src/rpp/rpp-coroutines.cppm
+++ b/src/rpp/rpp-coroutines.cppm
@@ -1,0 +1,25 @@
+// C++20 module interface unit for <rpp/coroutines.h>.
+module;
+
+// global module fragment: the header stays here, so an importer and an includer share one entity
+#include "coroutines.h"
+
+export module rpp.coroutines;
+
+// GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
+
+export namespace rpp {
+#if RPP_HAS_COROUTINES
+    using rpp::functor_awaiter;
+    using rpp::functor_awaiter_fut;
+    using rpp::std_future_awaiter;
+    using rpp::time_awaiter;
+#endif
+}
+
+export namespace rpp::inline coro_operators {
+#if RPP_HAS_COROUTINES
+    using rpp::coro_operators::operator co_await;
+#endif
+}
+// GENERATED EXPORTS END

--- a/src/rpp/rpp-coroutines.cppm
+++ b/src/rpp/rpp-coroutines.cppm
@@ -9,17 +9,13 @@ export module rpp.coroutines;
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
 
 export namespace rpp {
-#if RPP_HAS_COROUTINES
     using rpp::functor_awaiter;
     using rpp::functor_awaiter_fut;
     using rpp::std_future_awaiter;
     using rpp::time_awaiter;
-#endif
 }
 
 export namespace rpp::inline coro_operators {
-#if RPP_HAS_COROUTINES
     using rpp::coro_operators::operator co_await;
-#endif
 }
 // GENERATED EXPORTS END

--- a/src/rpp/rpp-event_loop.cppm
+++ b/src/rpp/rpp-event_loop.cppm
@@ -9,9 +9,7 @@ export module rpp.event_loop;
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
 
 export namespace rpp {
-#if RPP_HAS_COROUTINES
     using rpp::event_task;
     using rpp::event_loop;
-#endif
 }
 // GENERATED EXPORTS END

--- a/src/rpp/rpp-future_types.cppm
+++ b/src/rpp/rpp-future_types.cppm
@@ -10,15 +10,13 @@ export module rpp.future_types;
 
 export namespace rpp {
     using rpp::cfuture;
+    using rpp::coro_handle;
+    using rpp::suspend_never;
+    using rpp::suspend_always;
     using rpp::IsFuture;
     using rpp::NotFuture;
     using rpp::IsFunction;
     using rpp::IsFunctionReturningFuture;
     using rpp::IsFunctionNotReturningFuture;
-#if RPP_HAS_COROUTINES
-    using rpp::coro_handle;
-    using rpp::suspend_never;
-    using rpp::suspend_always;
-#endif
 }
 // GENERATED EXPORTS END

--- a/src/rpp/rpp-semaphore.cppm
+++ b/src/rpp/rpp-semaphore.cppm
@@ -9,12 +9,10 @@ export module rpp.semaphore;
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
 
 export namespace rpp {
+    using rpp::parallel_task_detached;
     using rpp::semaphore;
     using rpp::semaphore_flag;
     using rpp::semaphore_once_flag;
     using rpp::atomic_test_and_set;
-#if RPP_HAS_COROUTINES
-    using rpp::parallel_task_detached;
-#endif
 }
 // GENERATED EXPORTS END

--- a/src/rpp/rpp-task.cppm
+++ b/src/rpp/rpp-task.cppm
@@ -9,18 +9,14 @@ export module rpp.task;
 // GENERATED EXPORTS BEGIN, tools/gen_module_exports.py owns this block
 
 export namespace rpp {
-#if RPP_HAS_COROUTINES
     using rpp::task;
     using rpp::deferred;
-#endif
 }
 
 export namespace rpp::detail {
-#if RPP_HAS_COROUTINES
     using rpp::detail::task_final_awaiter;
     using rpp::detail::take_result;
     using rpp::detail::task_promise;
     using rpp::detail::task_base;
-#endif
 }
 // GENERATED EXPORTS END

--- a/src/rpp/semaphore.h
+++ b/src/rpp/semaphore.h
@@ -7,10 +7,8 @@
 #include "predicates.h" // rpp::IsCallable
 #include <atomic>
 
-#if RPP_HAS_CXX20
-#  include "future_types.h" // rpp::coro_handle
-#    include "delegate.h" // rpp::delegate (for coroutine awaiter)
-#endif
+#include "future_types.h" // rpp::coro_handle
+#include "delegate.h" // rpp::delegate (for coroutine awaiter)
 
 namespace rpp
 {

--- a/src/rpp/semaphore.h
+++ b/src/rpp/semaphore.h
@@ -8,18 +8,14 @@
 #include <atomic>
 
 #if RPP_HAS_CXX20
-#  include "future_types.h" // RPP_HAS_COROUTINES, rpp::coro_handle
-#  if RPP_HAS_COROUTINES
+#  include "future_types.h" // rpp::coro_handle
 #    include "delegate.h" // rpp::delegate (for coroutine awaiter)
-#  endif
 #endif
 
 namespace rpp
 {
-#if RPP_HAS_COROUTINES
     // forward declaration: avoids circular include with thread_pool.h
     void parallel_task_detached(rpp::delegate<void()>&& genericTask) noexcept;
-#endif
 
     //////////////////////////////////////////////////////////////////////////////////////////
 
@@ -363,7 +359,6 @@ namespace rpp
             hasFinished = false;
         }
 
-#if RPP_HAS_COROUTINES
         /**
          * @brief Awaitable handle for co_await on semaphore wait.
          * Dispatches the blocking wait to a background thread and resumes the coroutine.
@@ -394,7 +389,6 @@ namespace rpp
             wait_result await_resume() noexcept { return result; }
         };
         RPP_CORO_WRAPPER co_await_handle await(rpp::Duration timeout) noexcept { return { *this, timeout }; }
-#endif
     };
 
     /**
@@ -428,10 +422,8 @@ namespace rpp
         using semaphore::try_wait;
         using semaphore::wait;
         using semaphore::wait_no_unset;
-#if RPP_HAS_COROUTINES
         using semaphore::co_await_handle;
         using semaphore::await;
-#endif
     };
 
     /**
@@ -481,10 +473,8 @@ namespace rpp
         {
             return wait_no_unset(lock, timeout);
         }
-#if RPP_HAS_COROUTINES
         using semaphore::co_await_handle;
         using semaphore::await;
-#endif
     };
 
     //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rpp/sockets.cpp
+++ b/src/rpp/sockets.cpp
@@ -1819,13 +1819,8 @@ namespace rpp
     }
 
 
-#if RPP_HAS_CXX20
     int socket::poll(std::span<socket* const> in, std::vector<int>& ready,
                      int timeoutMillis, PollFlag pollFlags) noexcept
-#else
-    int socket::poll(const std::vector<socket*>& in, std::vector<int>& ready,
-                     int timeoutMillis, PollFlag pollFlags) noexcept
-#endif
     {
         ready.resize(in.size());
 

--- a/src/rpp/sockets.h
+++ b/src/rpp/sockets.h
@@ -12,9 +12,7 @@
 #include <vector>   // std::vector
 #include <optional> // std::optional
 #include "mutex.h"
-#if RPP_HAS_CXX20
-#  include <span>
-#endif
+#include <span>   // std::span
 
 namespace rpp
 {
@@ -674,12 +672,10 @@ namespace rpp
         int send(const std::vector<uint8_t>& bytes) noexcept {
             return send(bytes.data(), static_cast<int>(bytes.size()));
         }
-    #if RPP_HAS_CXX20
         // Send a span of bytes
         int send(std::span<const uint8_t> bytes) noexcept {
             return send(bytes.data(), static_cast<int>(bytes.size()));
         }
-    #endif
         // Send a C++ string
         template<class T> int send(const std::basic_string<T>& str) noexcept { 
             return this->send(str.data(), static_cast<int>(sizeof(T) * str.size())); 
@@ -714,12 +710,10 @@ namespace rpp
         int sendto(const ipaddress& to, const std::vector<char>& bytes) noexcept {
             return sendto(to, bytes.data(), static_cast<int>(bytes.size()));
         }
-    #if RPP_HAS_CXX20
         // Send a span of bytes
         int sendto(const ipaddress& to, std::span<const uint8_t> bytes) noexcept {
             return sendto(to, bytes.data(), static_cast<int>(bytes.size()));
         }
-    #endif
         /** Send a C++ string */
         template<class T> int sendto(const ipaddress& to, const std::basic_string<T>& str) noexcept {
             return this->sendto(to, str.data(), static_cast<int>(sizeof(T) * str.size()));
@@ -1201,14 +1195,9 @@ namespace rpp
          *          Ready vector is cleared before use and reserved to fit in.size() indexes.
          *          To handle errors, you must check each socket last_err() individually
          */
-    #if RPP_HAS_CXX20
         static int poll(std::span<socket* const> in, std::vector<int>& ready,
                         int timeoutMillis, PollFlag pollFlags = PF_Read) noexcept;
-    #else
-        static int poll(const std::vector<socket*>& in, std::vector<int>& ready,
-                        int timeoutMillis, PollFlag pollFlags = PF_Read) noexcept;
-    #endif
-        
+
         /** 
          * @brief Enables polling multiple sockets for READ/WRITE readiness
          * @param in Array of socket pointers to poll
@@ -1225,7 +1214,6 @@ namespace rpp
         static int poll(socket* const* in, int inCount, int* outReadyIndexes, int outMaxCount,
                         int timeoutMillis, PollFlag pollFlags = PF_Read) noexcept;
 
-    #if RPP_HAS_CXX20
         /**
          * @brief Enables polling multiple sockets for READ/WRITE readiness
          * @param in Span of socket pointers to poll
@@ -1244,7 +1232,6 @@ namespace rpp
                         outReadyIndexes.data(), static_cast<int>(outReadyIndexes.size()),
                         timeoutMillis, pollFlags);
         }
-    #endif
 
     private:
         bool on_poll_result(int revents, PollFlag pollFlags) noexcept;

--- a/src/rpp/sort.h
+++ b/src/rpp/sort.h
@@ -7,15 +7,11 @@
  */
 #include "config.h"
 #include <stddef.h> // size_t
-#if RPP_HAS_CXX20
-#  include <concepts> // std::same_as
-#  include <type_traits> // std::is_pointer
-#endif
+#include <concepts> // std::same_as
+#include <type_traits> // std::is_pointer
 
 namespace rpp
 {
-
-#if RPP_HAS_CXX20
     /**
      * @brief Concept for a comparison function used in sorting,
      *        which should be a callable with signature: bool(const T& a, const T& b)
@@ -46,7 +42,6 @@ namespace rpp
      */
     template<contiguous_container Container>
     using container_element_t = std::decay_t<decltype(std::declval<Container&>().data()[0])>;
-#endif
 
     /**
      * @brief A simple insertion sort algorithm
@@ -58,9 +53,7 @@ namespace rpp
     template<typename T, typename Comparison>
     NOINLINE void insertion_sort(T* data, size_t count, const Comparison& comparison)
         noexcept(noexcept(comparison(data[0], data[0])) && noexcept(std::swap(data[0], data[0])))
-        #if RPP_HAS_CXX20
-            requires sort_comparison<T, Comparison>
-        #endif
+        requires sort_comparison<T, Comparison>
     {
         for (size_t i = 1; i < count; ++i)
         {
@@ -81,10 +74,8 @@ namespace rpp
     template<typename Container, typename Comparison>
     FINLINE void insertion_sort(Container& container, const Comparison& comparison)
         noexcept(noexcept(insertion_sort(container.data(), container.size(), comparison)))
-        #if RPP_HAS_CXX20
-            requires contiguous_container<Container> &&
-                     sort_comparison<container_element_t<Container>, Comparison>
-        #endif
+        requires contiguous_container<Container> &&
+                 sort_comparison<container_element_t<Container>, Comparison>
     {
         insertion_sort(container.data(), container.size(), comparison);
     }
@@ -95,9 +86,7 @@ namespace rpp
      */
     template<typename Container>
     FINLINE void sort(Container&& container)
-        #if RPP_HAS_CXX20
-            requires contiguous_container<Container>
-        #endif
+        requires contiguous_container<Container>
     {
         insertion_sort(container.data(), container.size(),
                        [](const auto& a, const auto& b) { return a < b; });
@@ -110,10 +99,8 @@ namespace rpp
      */
     template<typename Container, typename Comparison>
     FINLINE void sort(Container&& container, const Comparison& comparison)
-        #if RPP_HAS_CXX20
-            requires contiguous_container<Container> &&
-                     sort_comparison<container_element_t<Container>, Comparison>
-        #endif
+        requires contiguous_container<Container> &&
+                 sort_comparison<container_element_t<Container>, Comparison>
     {
         insertion_sort(container.data(), container.size(), comparison);
     }

--- a/src/rpp/source_loc.h
+++ b/src/rpp/source_loc.h
@@ -6,7 +6,7 @@
  */
 #include "config.h"
 
-#if RPP_HAS_CXX20 && __has_include(<source_location>)
+#if __has_include(<source_location>)
 #include <source_location> // std::source_location for better assert messages
 #  define RPP_HAS_SOURCE_LOCATION 1
 #  define RPP_SOURCE_LOC rpp::source_loc loc = { std::source_location::current() }

--- a/src/rpp/task.h
+++ b/src/rpp/task.h
@@ -9,10 +9,9 @@
  * Copyright (c) 2026, Jorma Rebane
  * Distributed under MIT Software License
  */
-#include "future_types.h" // RPP_HAS_COROUTINES
+#include "future_types.h" // rpp::coro_handle, rpp::suspend_never
 
-#if RPP_HAS_COROUTINES
-// NOTE: future_types.h already includes <coroutine> and exposes rpp::coro_handle / rpp::suspend_* / RPP_CORO_STD
+// NOTE: future_types.h already includes <coroutine> and exposes rpp::coro_handle and rpp::suspend_*
 #include <exception> // std::exception_ptr
 #include <type_traits> // std::conditional_t, std::is_void_v
 #include <utility> // std::exchange, std::move
@@ -76,7 +75,7 @@ namespace rpp
             rpp::coro_handle<> await_suspend(rpp::coro_handle<Promise> h) const noexcept
             {
                 rpp::coro_handle<> cont = h.promise().continuation;
-                return cont ? cont : RPP_CORO_STD::noop_coroutine();
+                return cont ? cont : std::noop_coroutine();
             }
             void await_resume() const noexcept {}
         };
@@ -197,7 +196,7 @@ namespace rpp
                         return handle;
                     }
                 }
-                return RPP_CORO_STD::noop_coroutine();
+                return std::noop_coroutine();
             }
 
             typename Promise::value_type await_resume() { return detail::take_result<typename Promise::value_type>(handle); }
@@ -240,4 +239,3 @@ namespace rpp
         }
     };
 } // namespace rpp
-#endif // RPP_HAS_COROUTINES

--- a/src/rpp/tests.h
+++ b/src/rpp/tests.h
@@ -61,7 +61,7 @@ namespace rpp
         /**
          * Simple coroutine return type for test cases.
          * Runs synchronously with suspend/resume points driven by the test runner.
-         * Use co_await std::suspend_always{} to create yield points.
+         * Use co_await rpp::suspend_always{} to create yield points.
          */
         struct RPP_CORO_RETURN_TYPE test_coro
         {
@@ -70,17 +70,17 @@ namespace rpp
                 std::exception_ptr exception;
                 test_coro get_return_object() noexcept
                 {
-                    return test_coro{std::coroutine_handle<promise_type>::from_promise(*this)};
+                    return test_coro{rpp::coro_handle<promise_type>::from_promise(*this)};
                 }
-                std::suspend_never initial_suspend() noexcept { return {}; }
-                std::suspend_always final_suspend() noexcept { return {}; }
+                rpp::suspend_never initial_suspend() noexcept { return {}; }
+                rpp::suspend_always final_suspend() noexcept { return {}; }
                 void return_void() noexcept {}
                 void unhandled_exception() noexcept { exception = std::current_exception(); }
             };
 
-            std::coroutine_handle<promise_type> handle;
+            rpp::coro_handle<promise_type> handle;
 
-            explicit test_coro(std::coroutine_handle<promise_type> h) noexcept : handle{h} {}
+            explicit test_coro(rpp::coro_handle<promise_type> h) noexcept : handle{h} {}
             test_coro(test_coro&& o) noexcept : handle{o.handle} { o.handle = nullptr; }
             ~test_coro() { if (handle) handle.destroy(); }
             test_coro(const test_coro&) = delete;

--- a/src/rpp/tests.h
+++ b/src/rpp/tests.h
@@ -7,7 +7,7 @@
 #include "sprint.h" // we love strview and sprint, so it's a common dependency
 #include "debugging.h" // for adapting debugging API-s with tests API
 #include "./math.h" // rpp::min, rpp::max
-#include "future_types.h" // RPP_HAS_COROUTINES and to support TestCaseCoro()
+#include "future_types.h" // <coroutine> and rpp::coro_handle, which test_coro needs
 #include "source_loc.h" // rpp::source_loc
 #include "minmax.h" // rpp::max
 #include "strview.h" // rpp::strview
@@ -58,7 +58,6 @@ namespace rpp
     {
         struct dummy { };
 
-    #if RPP_HAS_COROUTINES
         /**
          * Simple coroutine return type for test cases.
          * Runs synchronously with suspend/resume points driven by the test runner.
@@ -71,17 +70,17 @@ namespace rpp
                 std::exception_ptr exception;
                 test_coro get_return_object() noexcept
                 {
-                    return test_coro{RPP_CORO_STD::coroutine_handle<promise_type>::from_promise(*this)};
+                    return test_coro{std::coroutine_handle<promise_type>::from_promise(*this)};
                 }
-                RPP_CORO_STD::suspend_never initial_suspend() noexcept { return {}; }
-                RPP_CORO_STD::suspend_always final_suspend() noexcept { return {}; }
+                std::suspend_never initial_suspend() noexcept { return {}; }
+                std::suspend_always final_suspend() noexcept { return {}; }
                 void return_void() noexcept {}
                 void unhandled_exception() noexcept { exception = std::current_exception(); }
             };
 
-            RPP_CORO_STD::coroutine_handle<promise_type> handle;
+            std::coroutine_handle<promise_type> handle;
 
-            explicit test_coro(RPP_CORO_STD::coroutine_handle<promise_type> h) noexcept : handle{h} {}
+            explicit test_coro(std::coroutine_handle<promise_type> h) noexcept : handle{h} {}
             test_coro(test_coro&& o) noexcept : handle{o.handle} { o.handle = nullptr; }
             ~test_coro() { if (handle) handle.destroy(); }
             test_coro(const test_coro&) = delete;
@@ -100,7 +99,6 @@ namespace rpp
             }
             bool done() const noexcept { return !handle || handle.done(); }
         };
-    #endif // RPP_HAS_COROUTINES
 
         // minimal version from delegate.h for impossibly fast delegates
         #if _MSC_VER  // VC++
@@ -123,7 +121,6 @@ namespace rpp
             dummy_type dfunc;
         };
 
-    #if RPP_HAS_COROUTINES
         // function pointer types for coroutine test cases (returning test_coro)
         #if _MSC_VER  // VC++
             #if INTPTR_MAX != INT64_MAX // __thiscall only applies for 32-bit MSVC
@@ -144,7 +141,6 @@ namespace rpp
             coro_memb_type mfunc;
             coro_dummy_type dfunc;
         };
-    #endif // RPP_HAS_COROUTINES
     
         struct test_func;
         struct test_impl;
@@ -249,10 +245,8 @@ namespace rpp
         virtual void test_case_setup() {}
         virtual void test_case_cleanup() {}
 
-    #if RPP_HAS_COROUTINES
         // override to provide a custom coroutine runner (e.g. event loop driven)
         virtual void run_coro_test(test_coro& coro) { coro.run_until_done(); }
-    #endif // RPP_HAS_COROUTINES
 
         bool run_init();
         void run_cleanup();
@@ -407,7 +401,6 @@ namespace rpp
             return self->add_test_func(name, fn, expectedExHash, autorun);
         }
 
-    #if RPP_HAS_COROUTINES
         int add_coro_test_func(strview name, coro_func_type fn, size_t expectedExHash, bool autorun);
 
         // adds a coroutine test to the automatic test run list
@@ -431,7 +424,6 @@ namespace rpp
             size_t expectedExHash = ti ? ti->hash_code() : 0;
             return self->add_coro_test_func(name, fn, expectedExHash, autorun);
         }
-    #endif // RPP_HAS_COROUTINES
     };
 
     struct Compare

--- a/src/rpp/tests.macros.h
+++ b/src/rpp/tests.macros.h
@@ -10,11 +10,11 @@
  *   #include <rpp/tests.macros.h>   // module: add this line for the macros
  *
  * Each macro below calls a name that <rpp/tests.h> or `import rpp.tests` declares.
- * Include one of the two first. The includes here carry the two macros an import cannot,
- * plus the three std names the macros expand to.
+ * Include one of the two first. The includes here carry the one macro an import cannot,
+ * plus the four std names the macros expand to.
  */
 #include "source_loc.h" // RPP_SOURCE_LOC_CURRENT
-#include "future_types.h" // RPP_HAS_COROUTINES, which guards TestCaseCoro
+#include "future_types.h" // re-export: a TestCaseCoro body needs the <coroutine> this brings
 #include <memory> // std::unique_ptr, which __TestInit returns
 #include <typeinfo> // typeid, which TestCaseExpectedEx takes
 #include <exception> // std::exception, which AssertNoThrowAny catches
@@ -226,12 +226,10 @@
     const int _test_##testname = add_test_func(self(), #testname, &ClassType::test_##testname ); \
     void test_##testname()
 
-#if RPP_HAS_COROUTINES
 // allows to use co_await in test cases, driven synchronously by the test runner
 #define TestCaseCoro(testname) \
     const int _test_##testname = add_coro_test_func(self(), #testname, &ClassType::test_##testname ); \
     rpp::test::test_coro test_##testname()
-#endif // RPP_HAS_COROUTINES
 
 #define TestCaseExpectedEx(testname, expectedExceptionType) \
     const int _test_##testname = add_test_func(self(), #testname, &ClassType::test_##testname, &typeid(expectedExceptionType)); \

--- a/src/rpp/timer.h
+++ b/src/rpp/timer.h
@@ -186,16 +186,8 @@ namespace rpp
         ScopedPerfTimer(const char* prefix, const char* location, const char* detail, unsigned long threshold_us = 0) noexcept;
         ScopedPerfTimer(const char* prefix, const char* location, unsigned long threshold_us = 0) noexcept
             : ScopedPerfTimer{prefix, location, nullptr, threshold_us} {}
-    #if RPP_HAS_CXX20 || _MSC_VER >= 1926 || defined(__GNUC__)
         explicit ScopedPerfTimer(const char* location = __builtin_FUNCTION()) noexcept
             : ScopedPerfTimer{"[perf]", location, nullptr, 0} {}
-    #else
-        ScopedPerfTimer() noexcept
-            : ScopedPerfTimer{"[perf]", "unknown location", nullptr, 0} {}
-        /** @brief For backwards compatibility */
-        explicit ScopedPerfTimer(const char* location) noexcept
-            : ScopedPerfTimer{"[perf]", location, nullptr, 0} {}
-    #endif
         ~ScopedPerfTimer() noexcept;
     };
 

--- a/tests/module_consumer/tests_module_only.cpp
+++ b/tests/module_consumer/tests_module_only.cpp
@@ -6,10 +6,8 @@
 
 import rpp.tests; // includes come first, the import goes last
 
-// future_types.h always defines this, and no import can carry a macro
-#ifndef RPP_HAS_COROUTINES
-#error tests.macros.h stopped including future_types.h, so TestCaseCoro went dark
-#endif
+// tests.macros.h re-exports future_types.h for <coroutine>, and the coroutine case below is
+// what pins it. Drop that include and this file stops finding std::coroutine_traits.
 
 TestImpl(module_only_suite)
 {
@@ -34,13 +32,11 @@ TestImpl(module_only_suite)
         throw std::runtime_error{"expected"};
     }
 
-#if RPP_HAS_COROUTINES // the macro comes from future_types.h, and no import can carry it
     TestCaseCoro(a_coroutine_case_compiles)
     {
         AssertThat(1, 1);
         co_return;
     }
-#endif
 };
 
 int main()

--- a/tests/test_concurrent_queue.cpp
+++ b/tests/test_concurrent_queue.cpp
@@ -789,7 +789,6 @@ TestImpl(test_concurrent_queue)
         print_info("AVERAGE wait_pop_interval consumer elapsed: %.2f ms  %.1f Mitems/s\n", avg_time, Mitems_per_sec);
     }
 
-#if RPP_HAS_COROUTINES
     // NOLINTBEGIN(cppcoreguidelines-avoid-capturing-lambda-coroutines)
     // NOTE: TestCaseCoro cannot be used here because the standalone awaiters
     // resume on a background thread, which conflicts with the default test
@@ -906,5 +905,4 @@ TestImpl(test_concurrent_queue)
     }
 
     // NOLINTEND(cppcoreguidelines-avoid-capturing-lambda-coroutines)
-#endif // RPP_HAS_COROUTINES
 };

--- a/tests/test_coroutines.cpp
+++ b/tests/test_coroutines.cpp
@@ -22,7 +22,6 @@ TestImpl(test_coroutines)
         rpp::thread_pool::global().clear_idle_tasks();
     }
 
-#if RPP_HAS_COROUTINES
 
     template<class T>
     void set_locked(T& out, const T& value)
@@ -291,5 +290,4 @@ TestImpl(test_coroutines)
         AssertThat(s, "future string"s);
     }
 
-#endif
 };

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -27,7 +27,6 @@ TestImpl(test_event_loop)
         rpp::thread_pool::global().clear_idle_tasks();
     }
 
-#if RPP_HAS_COROUTINES
 
     rpp::AtomicTimeSource clock;
     // a loop can hold a raw pointer to this pool, so the pool must outlive the loop
@@ -1359,5 +1358,4 @@ TestImpl(test_event_loop)
 
     // NOLINTEND(cppcoreguidelines-avoid-capturing-lambda-coroutines)
 
-#endif // RPP_HAS_COROUTINES
 };

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -620,7 +620,7 @@ TestImpl(test_modules)
 
     TestCase(coroutines_module_carries_the_whole_surface)
     {
-        // every awaiter suspends onto the pool, so the probe drives await_ready() on its own
+        // a cfuture coroutine instantiates std::promise, so the probe drives await_ready() directly, see BUGS.md B16
         rpp::time_awaiter elapsed { rpp::TimePoint::monotonic_now() };
         AssertThat(elapsed.await_ready(), true);
 
@@ -631,8 +631,13 @@ TestImpl(test_modules)
         rpp::functor_awaiter<int> functor { rpp::delegate<int()>{ +[] { return 7; } } };
         AssertThat(functor.await_ready(), false);
 
-        static_assert(sizeof(rpp::functor_awaiter_fut<rpp::cfuture<int>>) > 0);
-        static_assert(sizeof(rpp::std_future_awaiter<int>) > 0);
+        // the constrained overloads pick a different awaiter, so each one needs its own probe
+        static_assert(std::is_same_v<decltype(operator co_await(rpp::delegate<int()>{})), rpp::functor_awaiter<int>>);
+        static_assert(std::is_same_v<decltype(operator co_await(std::future<int>{})), rpp::std_future_awaiter<int>>);
+
+        static_assert(sizeof(rpp::functor_awaiter<void>) > 0, "the module must export functor_awaiter<void>");
+        static_assert(sizeof(rpp::functor_awaiter_fut<rpp::cfuture<int>>) > 0, "the module must export functor_awaiter_fut");
+        static_assert(sizeof(rpp::std_future_awaiter<int>) > 0, "the module must export std_future_awaiter");
     }
 #endif
 };

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -586,7 +586,6 @@ TestImpl(test_modules)
         rpp::run_tasks(no_items, &module_launch);
     }
 
-#if RPP_HAS_COROUTINES
     // an eager task runs to completion at construction, so this needs no event loop
     static rpp::task<int> module_task() { co_return 99; }
 
@@ -639,7 +638,6 @@ TestImpl(test_modules)
         static_assert(sizeof(rpp::functor_awaiter_fut<rpp::cfuture<int>>) > 0, "the module must export functor_awaiter_fut");
         static_assert(sizeof(rpp::std_future_awaiter<int>) > 0, "the module must export std_future_awaiter");
     }
-#endif
 };
 
 #endif // RPP_BUILD_WITH_MODULES

--- a/tests/test_modules.cpp
+++ b/tests/test_modules.cpp
@@ -54,6 +54,7 @@ import rpp.binary_serializer;
 import rpp.thread_pool;
 import rpp.future;
 import rpp.event_loop;
+import rpp.coroutines;
 
 // test_modules_identity.cpp takes this address through the module and includes no rpp header
 const void* module_pi_addr() noexcept;
@@ -615,6 +616,23 @@ TestImpl(test_modules)
         rpp::event_task task = module_event_task(&value);
         AssertThat(value, 3);
         AssertThat(task.done(), true);
+    }
+
+    TestCase(coroutines_module_carries_the_whole_surface)
+    {
+        // every awaiter suspends onto the pool, so the probe drives await_ready() on its own
+        rpp::time_awaiter elapsed { rpp::TimePoint::monotonic_now() };
+        AssertThat(elapsed.await_ready(), true);
+
+        using namespace rpp::coro_operators; // the module exports the inline namespace too
+        rpp::time_awaiter pending = operator co_await(rpp::seconds(1));
+        AssertThat(pending.await_ready(), false);
+
+        rpp::functor_awaiter<int> functor { rpp::delegate<int()>{ +[] { return 7; } } };
+        AssertThat(functor.await_ready(), false);
+
+        static_assert(sizeof(rpp::functor_awaiter_fut<rpp::cfuture<int>>) > 0);
+        static_assert(sizeof(rpp::std_future_awaiter<int>) > 0);
     }
 #endif
 };

--- a/tests/test_semaphore.cpp
+++ b/tests/test_semaphore.cpp
@@ -364,7 +364,6 @@ TestImpl(test_semaphore)
         }
     }
 
-#if RPP_HAS_COROUTINES
     // NOLINTBEGIN(cppcoreguidelines-avoid-capturing-lambda-coroutines)
     // NOTE: TestCaseCoro cannot be used here because the standalone awaiters
     // resume on a background thread, which conflicts with the default test
@@ -415,5 +414,4 @@ TestImpl(test_semaphore)
     }
 
     // NOLINTEND(cppcoreguidelines-avoid-capturing-lambda-coroutines)
-#endif // RPP_HAS_COROUTINES
 };

--- a/tests/test_task.cpp
+++ b/tests/test_task.cpp
@@ -13,7 +13,6 @@ using namespace rpp;
 // The leaves here use loop.run_async(), which hops to a pool worker and posts the resume back to
 // the loop, so a task chain over those leaves stays on the loop thread end-to-end.
 
-#if RPP_HAS_COROUTINES
 
 // the loop outlives every coroutine below, so a reference parameter cannot dangle
 // NOLINTBEGIN(cppcoreguidelines-avoid-capturing-lambda-coroutines,cppcoreguidelines-avoid-reference-coroutine-parameters)
@@ -81,13 +80,11 @@ namespace
         co_return 7;
     }
 } // namespace
-#endif
 
 TestImpl(test_task)
 {
     TestInit(test_task) {}
 
-#if RPP_HAS_COROUTINES
 
     std::unique_ptr<rpp::event_loop> loop;
     const uint64 main_tid = rpp::get_thread_id();
@@ -281,5 +278,4 @@ TestImpl(test_task)
 
     // NOLINTEND(cppcoreguidelines-avoid-capturing-lambda-coroutines,cppcoreguidelines-avoid-reference-coroutine-parameters)
 
-#endif // RPP_HAS_COROUTINES
 };

--- a/tests/test_timer.cpp
+++ b/tests/test_timer.cpp
@@ -571,11 +571,16 @@ TestImpl(test_timer)
     {
         rpp::TimePoint t1 = rpp::TimePoint::now(rpp::ClockType::ThreadCPU);
         AssertThat(t1.is_valid(), true);
-        spin_sleep_for_us(20'000, /*full_spin*/true);
-        rpp::TimePoint t2 = rpp::TimePoint::now(rpp::ClockType::ThreadCPU);
-        rpp::int64 elapsed_us = (t2 - t1).micros();
-        print_info("ThreadCPU 20ms spin elapsed: %lldus\n", elapsed_us);
-        // CPU time granularity on CI VMs can be ~10ms, so only assert non-zero
+
+        // GetThreadTimes reports whole ~15.6ms ticks, so one 20ms spin can start and end
+        // inside a single tick and read 0. Spin again until a tick lands, at most 10 times.
+        rpp::int64 elapsed_us = 0;
+        for (int spins = 0; spins < 10 && elapsed_us == 0; ++spins)
+        {
+            spin_sleep_for_us(20'000, /*full_spin*/true);
+            elapsed_us = (rpp::TimePoint::now(rpp::ClockType::ThreadCPU) - t1).micros();
+        }
+        print_info("ThreadCPU spin elapsed: %lldus\n", elapsed_us);
         AssertGreater(elapsed_us, 0);
     }
 

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -29,8 +29,9 @@ GUARDS = (('RPP_ENABLE_UNICODE', ('RPP_ENABLE_UNICODE=0',)),
           ('!defined(RPP_BINARY_READWRITE_NO_FILE_IO)', ('RPP_BINARY_READWRITE_NO_FILE_IO=1',)))
 
 # a macro no define reaches, because the header derives it from __has_include. The generator
-# reads the region the header guards with it instead of parsing a second configuration
-TEXT_GUARDS = ('RPP_HAS_COROUTINES',)
+# reads the region the header guards with it instead of parsing a second configuration.
+# Empty since RPP_HAS_COROUTINES went, and the selftest still drives the rule
+TEXT_GUARDS = ()
 
 # a using-declaration cannot name these, and an importer never needs them
 # this set omits UNEXPOSED_DECL, because libclang reports a variable template under that
@@ -163,15 +164,15 @@ def internal_names(header: str, allow: frozenset = None) -> list:
     return out
 
 
-def _guarded_spans(header: str) -> dict:
-    """Macro to the line spans its `#if` blocks cover, for every macro in TEXT_GUARDS.
+def _guarded_spans(header: str, macros: tuple = None) -> dict:
+    """Macro to the line spans its `#if` blocks cover, for every macro in `macros`.
 
     A span holds line numbers, not text. A block which only mentions an unconditional class
     would otherwise guard that whole class, and hide its API wherever the macro is 0.
     """
     lines = _read(header).split('\n')
     out = {}
-    for macro in TEXT_GUARDS:
+    for macro in (TEXT_GUARDS if macros is None else macros):
         spans, depth, start = [], 0, None
         for i, line in enumerate(lines, 1):
             s = line.strip()
@@ -352,7 +353,7 @@ def selftest() -> list:
         for name in ('TAU', 'Public'):
             if name not in shown: bad.append(f'{name} has external linkage and left the export list')
         if any(n.startswith('<') for n in shown): bad.append('a deduction guide reached the export list')
-        spans = _guarded_spans(path)
+        spans = _guarded_spans(path, ('RPP_HAS_COROUTINES',))
         base = _exported(path, BASE)
         if _condition('rpp', 'Awaited', rpp_ns['Awaited'], base, {}, spans) != 'RPP_HAS_COROUTINES':
             bad.append('a declaration inside a guard span took no #if')

--- a/tools/gen_module_exports.py
+++ b/tools/gen_module_exports.py
@@ -72,7 +72,8 @@ NO_CONFIG = {'semaphore.h': frozenset({'!RPP_BARE_METAL'}),
              'concurrent_queue.h': frozenset({'!RPP_BARE_METAL'}),
              'thread_pool.h': frozenset({'!RPP_BARE_METAL'}),
              'future.h': frozenset({'!RPP_BARE_METAL'}),
-             'event_loop.h': frozenset({'!RPP_BARE_METAL'})}
+             'event_loop.h': frozenset({'!RPP_BARE_METAL'}),
+             'coroutines.h': frozenset({'!RPP_BARE_METAL'})}
 
 # the condition a header declares for the names only an alternate configuration has, when the
 # guard the generator would negate is wider. mutex.h also declares critical_section on Cortex-M,

--- a/update_doc_linerefs.py
+++ b/update_doc_linerefs.py
@@ -164,6 +164,21 @@ def score_candidate(line_text: str, param_pairs: list[tuple[str, str]]) -> int:
     return score
 
 
+def count_declared_params(decl: str, name: str) -> int | None:
+    """Count the parameters the named function takes here, or None when the name has no
+    argument list. The name anchors the search, so `unset() { reset(0); }` counts reset."""
+    m = re.search(r'\b' + re.escape(name) + r'\s*\(', decl)
+    if not m:
+        return None
+    depth = 1
+    for i in range(m.end(), len(decl)):
+        if decl[i] == '(': depth += 1
+        elif decl[i] == ')':
+            depth -= 1
+            if depth == 0: return len(split_params(decl[m.end():i]))
+    return None
+
+
 def get_full_declaration(lines: list[str], line_idx: int) -> str:
     """Get the full declaration text starting at line_idx (0-based).
     If the line ends with a comma, continuation lines are joined
@@ -270,6 +285,14 @@ def find_line_in_lines(lines: list[str], display: str, search_name: str, old_lin
             if len(best) == 1:
                 return best[0]
             candidates = best
+
+    # An untyped display such as `sort(container)` scores nothing, so the param count
+    # separates it from a wider overload. Only an exact single hit wins.
+    if is_callable:
+        want = count_declared_params(display, bare_name)
+        same = [c for c in candidates
+                if count_declared_params(get_full_declaration(lines, c - 1), bare_name) == want]
+        if len(same) == 1: return same[0]
 
     # Fallback: prefer the one closest to the old line number
     return min(candidates, key=lambda c: abs(c - old_line))
@@ -469,6 +492,17 @@ def tests():
           find(queue_lines, "wait_pop(T& outItem)", 10), 10)
     check("wait_pop() -> L5",
           find(queue_lines, "wait_pop()", 5), 5)
+
+    # An untyped display scores 0 against every overload, so the param count decides.
+    # The old line sits nearer the wrong overload, which is what the count has to beat.
+    sort_lines = _make_lines({
+        10: '    FINLINE void sort(Container&& container)',
+        20: '    FINLINE void sort(Container&& container, const Comparison& comparison)',
+    })
+    check("sort(container) -> L10 despite old line 16",
+          find(sort_lines, "sort(container)", 16), 10)
+    check("sort(container, comparison) -> L20",
+          find(sort_lines, "sort(container, comparison)", 16), 20)
 
     # verify should reject mismatched display text
     check("verify wait_pop(Duration timeout) at L20 -> ok",


### PR DESCRIPTION
Three changes. The L8 layer finishes the header plan, the pre-C++20 clang support goes,
and the C++20 detection macro goes with it.

## L8: the last header ships

`rpp.coroutines` joins, so 44 modules ship and only the umbrella remains. It exports four
awaiter types and `rpp::coro_operators::operator co_await`, which carries nine overloads.
It is the first module to export an inline namespace of operators, and the generator writes
that as its own `export namespace` block:

```cpp
export namespace rpp {
    using rpp::functor_awaiter;
    using rpp::functor_awaiter_fut;
    using rpp::std_future_awaiter;
    using rpp::time_awaiter;
}

export namespace rpp::inline coro_operators {
    using rpp::coro_operators::operator co_await;
}
```

No generator change was needed. The inline-namespace rule landed with L2.

## The probe works around B16

B16 forbids a `std::promise` in this translation unit, and a `cfuture` coroutine builds one
through its promise type. So `coroutines_module_carries_the_whole_surface` constructs each
awaiter directly and drives `await_ready()` instead of writing a coroutine. A `time_awaiter`
built on a past `TimePoint` reports ready and one built on a future `TimePoint` does not,
which pins real behavior with no coroutine frame. Two unevaluated `decltype` lines pin the
constrained overloads, and `functor_awaiter<void>` takes its own probe.

## RPP_HAS_COROUTINES goes, and so does RPP_CORO_STD

`future_types.h` picked `<coroutine>` or `<experimental/coroutine>` and set both macros from
the answer. That second branch served clang-14 and older, and `config.h:80` already asserts
C++20, which such a clang cannot meet. The header includes `<coroutine>` alone now.

Four measurements say the macro was constant. gcc-14, clang-18 and `arm-none-eabi-g++` 13.2
on Cortex-M4 all report 1, bare metal included, and a C++17 build never compiles because the
assertion fires first. So 37 guard blocks across 23 files lose their `#if`, 14
`RPP_CORO_STD::` uses read `std::`, and seven lambdas drop a `/*clang-12 compat*/mutable`
marker.

The generator keeps its text-guard rule, which had this macro as its only user. `TEXT_GUARDS`
is empty and the selftest passes its own macro, so the rule stays proven with no stale name
in a production knob.

`tests.macros.h` keeps `future_types.h` as a marked re-export. A `TestCaseCoro` body is a
coroutine, so the translation unit needs the `<coroutine>` it brings, which the unused-include
scan cannot see. `tests_module_only.cpp` is what pins it, and it caught exactly that mistake
during this work.

## RPP_HAS_CXX20 goes too

The same argument covers the standard-detection macro. `config.h` asserted C++20 and then
defined `RPP_HAS_CXX20` from the same test, so every `#if RPP_HAS_CXX20` below it read 1.
The macro goes, and the assertion now tests `__cplusplus` and `_MSVC_LANG` itself:

```cpp
// C++20 is the floor, so a wrong -std stops here instead of deep inside a header
#if __cplusplus
#  if _MSC_VER
   static_assert(_MSVC_LANG >= 202002L, "ReCpp requires C++20 or higher");
#  else
   static_assert(__cplusplus >= 202002L, "ReCpp requires C++20 or higher");
#  endif
#endif
```

21 guard sites across 10 files lose their `#if`. `sort.h` carried six of them around the
concepts and every `requires` clause. `sockets.h` carried five around `<span>`, two `send`
overloads and two `poll` overloads. The `poll` fallback took a `const std::vector<socket*>&`,
and a caller still passes a vector, because `std::span<socket* const>` converts from one.

Three sites carried more than the bare macro, so each keeps the rest of its condition:

| Header | Was | Now |
|---|---|---|
| `source_loc.h` | `RPP_HAS_CXX20 && __has_include(<source_location>)` | `__has_include(<source_location>)` |
| `timer.h` | `RPP_HAS_CXX20 \|\| _MSC_VER >= 1926 \|\| defined(__GNUC__)` | no guard, the `#else` fallback goes |
| `debugging.h` | `RPP_HAS_CXX23 \|\| (RPP_HAS_CXX20 && __cpp_lib_constexpr_string && !RPP_GCC)` | `RPP_HAS_CXX23 \|\| (__cpp_lib_constexpr_string && !RPP_GCC)` |

`source_loc.h` keeps its `__has_include`, because an old libc++ ships C++20 without that
header, which is the case the header was written for. `timer.h` loses a
`__builtin_FUNCTION()` fallback which no C++20 compiler reaches. `RPP_HAS_CXX23` and
`RPP_HAS_CXX26` stay, because they still answer a real question.

`mutex.h` keeps `RPP_SYNC_T`, which now has one definition. Its `#else` branch said the same
thing as its `#if` branch, and README documents the macro, so only the `#if` goes.

## A doc tool defect the shorter sort.h exposed

`sort.h` lost 13 lines, which moved `sort(Container&&)` above its old line number.
`update_doc_linerefs.py` then pointed the `sort(container)` row at the two-argument overload.
An untyped display text scores 0 against every candidate, so the tool falls back to the
nearest old line number, and that sat nearer the wrong overload.

A parameter count filter now runs before that fallback, and only an exact single hit wins.
It fixes the two `sort` rows and corrects nine more which already pointed at the wrong
overload at `master`:

| Row | Pointed at | Now points at |
|---|---|---|
| `as_lower()` | `as_lower(char* dst)` | `as_lower()` |
| `as_upper()` | `as_upper(char* dst)` | `as_upper()` |
| `indexof(char ch)` | `indexof(char, int, int)` | `indexof(char)` |
| `next(char delim)` | `next(const char*, int)` | `next(char)` |
| `next(char16_t delim)` | `next(const char16_t*, int)` | `next(char16_t)` |
| `notify_once()` | a call site | the declaration |
| `stack_trace(maxDepth)` | `stack_trace(strview, size_t, ...)` | `stack_trace(size_t)` |
| `starts_with(const char* s, int len)` | the array template | the two-argument one |
| `starts_withi(const char* s, int len)` | the array template | the two-argument one |

The count anchors on the searched name, not on the first parentheses of the line. Without
that anchor `unset() noexcept { reset(0); }` counts zero parameters and steals the `reset()`
row. Two cases in the tool's own self-test pin the behavior, and the suite is 62/62.

## Two fixes CI found

`ubuntu-cpp20-modules-clang21` rejected a lambda which returned a `cfuture` without the
coroutine-wrapper attribute, the shape the migration plan records as finding 16. A named
launcher marked `RPP_CORO_WRAPPER` replaces it.

`win64-cpp20-msvc` failed `test_timer::clock_type_thread_cpu` twice. `GetThreadTimes` reports
whole ticks of about 15.6 ms, which `timepoint.h:63` documents, so a single 20 ms spin can
start and end inside one tick and read 0. The case spins again until a tick lands, at most
ten times, and a working clock still exits on the first spin.

## Bare metal

`coroutines.h` joins `NO_CONFIG`. It reaches the `cv.wait(lock)` of B15 through `future.h`
and `thread_pool.h`. B15 now names six headers, and B16 counts nine of its ten headers as
shipping modules.

## Gates

`BUILD_WITH_MODULES=AUTO` turns modules off below clang 21, and this container has clang
18.1.3. So the clang rows are the **header build**, and they compile neither the new `.cppm`
nor the new case. The arithmetic shows it: 579 minus 538 is 41, the case count of
`test_modules.cpp`. Only gcc-14 and CI cover the module path.

| Gate | Result |
|---|---|
| `CXX20=1 mama gcc build test="nogdb -vv"` | 579/579, modules build |
| `CXX23=1 mama gcc build test="nogdb -vv"` | 579/579, modules build |
| `CXX20=1 mama clang build test="nogdb -vv"` | 538/538, header build |
| `CXX23=1 mama clang build test="nogdb -vv"` | 538/538, header build |
| `CXX23=1 mama clang build clang-tidy test="nogdb -vv"` | 538/538, header build, 0 warnings |
| `tools/check_includes.py all` | the 4 gated checks report 0, `missing` 50 and `unused` 4 unchanged |
| `gen_module_exports.py --selftest` and `--all --check` | 0, and 0 over 44 modules |
| `update_doc_linerefs.py`, `--check-undocumented` and `--run-tests` | clean, clean, 62/62 |
| `tests/module_consumer/run_test.py --compare-paths --unicode-off g++` | OK, and all six module-only targets exit 0 |
| `arm-none-eabi-g++` 13.2, Cortex-M4 | 0 errors on `config.h`, `future_types.h` and `sort.h` |
| GitHub Actions CI | all 28 jobs pass on the L8 head, pending on this one |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJQak2qMQ4cXHtqEcpwimN