### PR TITLE
feature: event_loop::stop_and_wait_all_ready, one call for a shutdown

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -24,9 +24,9 @@ in `delegate::reset()` or in the copy path which calls it.
 ### B23. `set_time_source()` writes a plain pointer a `delay()` worker still reads
 `event_loop::time_source` is a raw pointer. A pending `delay()` reads it once to pick its poll
 branch, then polls `current_time()` from a background worker (`event_loop.h:814-820`). A
-`set_time_source()` call from the owner thread races that read. Worse than a torn read: the
-worker keeps a virtual `end` deadline and starts comparing it against wall time, so it polls
-until the deadline arrives in real time.
+`set_time_source()` call from the owner thread races that read. The damage is worse than a torn
+read. The worker keeps a virtual `end` deadline and compares it against wall time, so it polls
+until that deadline arrives in real time.
 
 `stop_and_wait_all_ready()` detaches only after every task finished, so it does not reach this.
 Any other caller which retimes a loop with work in flight does. A fix makes the field atomic

--- a/BUGS.md
+++ b/BUGS.md
@@ -8,19 +8,6 @@ names the fix. Git holds the story, and a longer entry is noise every agent read
 
 ## Open
 
-### B24. `delegate::operator=` leaks the old functor, so a second pop into one local leaks
-`event_loop::wait_on_all()` keeps one `resume_event event` and pops into it twice: once in the
-`try_pop` drain, once in the `wait_pop_until` loop. Each pop copy-assigns the delegate, and the
-assignment allocates a new functor without freeing the one already held.
-
-ASAN reports `Direct leak of 8 byte(s)` through `delegate::init_functor`
-(`delegate.h:571`) from `concurrent_queue::pop_unlocked` (`concurrent_queue.h:845`). One
-captured reference is 8 bytes, so the leak scales with the capture.
-
-Reproduce it by queuing a callback before `wait_on_all()` runs, so both loops pop. No test did
-that until PR #84 gated a worker that way, and reverting the gate hid it again. The fix belongs
-in `delegate::reset()` or in the copy path which calls it.
-
 ### B23. `set_time_source()` writes a plain pointer a `delay()` worker still reads
 `event_loop::time_source` is a raw pointer. A pending `delay()` reads it once to pick its poll
 branch, then polls `current_time()` from a background worker (`event_loop.h:814-820`). A
@@ -350,6 +337,11 @@ inside `DbgAssert`, not the `#define LogError` at line 139. Corrected by hand.
 The script's own docstring already warns that it has mistakes.
 
 ## Closed
+
+### C27. `delegate::copy` leaked the destination functor when the source was a function (was B24)
+The function branch of `copy()` overwrote `f` and `obj` and never freed the functor the
+destination owned. It calls `to.reset()` first now, which `copy_assign_from_function_frees_the_old_functor` pins.
+
 
 ### B24. gcc-14 wrote an `rpp.std` on C++23 which no importer could read
 The module compiled, every importer then stopped with `failed to read compiled module: Bad

--- a/BUGS.md
+++ b/BUGS.md
@@ -9,13 +9,15 @@ names the fix. Git holds the story, and a longer entry is noise every agent read
 ## Open
 
 ### B23. `set_time_source()` writes a plain pointer a `delay()` worker still reads
-`event_loop::time_source` is a raw pointer, and `delay()` polls it from a background worker
-(`event_loop.h:816`). `stop_and_wait_all_ready()` nulls it, so a worker which outlives the
-drain compares a virtual deadline against wall time, and TSAN sees an unsynchronized write.
+`event_loop::time_source` is a raw pointer. A pending `delay()` reads it once to pick its poll
+branch, then polls `current_time()` from a background worker (`event_loop.h:814-820`). A
+`set_time_source()` call from the owner thread races that read. Worse than a torn read: the
+worker keeps a virtual `end` deadline and starts comparing it against wall time, so it polls
+until the deadline arrives in real time.
 
-Only reachable when the drain already failed, and the call returns false there, so no
-shutdown path in ReCpp hits it. A fix makes the field atomic and loads it once per poll.
-Found by review on PR #84.
+`stop_and_wait_all_ready()` detaches only after every task finished, so it does not reach this.
+Any other caller which retimes a loop with work in flight does. A fix makes the field atomic
+and has the worker load it once per poll. Found by review on PR #84.
 
 ### B22. gcc-14 emits no `_M_release` for a `std::shared_ptr` an importer reaches through a module
 The interface compiles and so does the importer. The link then fails:

--- a/BUGS.md
+++ b/BUGS.md
@@ -8,6 +8,15 @@ names the fix. Git holds the story, and a longer entry is noise every agent read
 
 ## Open
 
+### B23. `set_time_source()` writes a plain pointer a `delay()` worker still reads
+`event_loop::time_source` is a raw pointer, and `delay()` polls it from a background worker
+(`event_loop.h:816`). `stop_and_wait_all_ready()` nulls it, so a worker which outlives the
+drain compares a virtual deadline against wall time, and TSAN sees an unsynchronized write.
+
+Only reachable when the drain already failed, and the call returns false there, so no
+shutdown path in ReCpp hits it. A fix makes the field atomic and loads it once per poll.
+Found by review on PR #84.
+
 ### B22. gcc-14 emits no `_M_release` for a `std::shared_ptr` an importer reaches through a module
 The interface compiles and so does the importer. The link then fails:
 

--- a/BUGS.md
+++ b/BUGS.md
@@ -338,7 +338,7 @@ The script's own docstring already warns that it has mistakes.
 
 ## Closed
 
-### C27. `delegate::copy` leaked the destination functor when the source was a function (was B24)
+### C29. `delegate::copy` leaked the destination functor when the source was a function
 The function branch of `copy()` overwrote `f` and `obj` and never freed the functor the
 destination owned. It calls `to.reset()` first now, which `copy_assign_from_function_frees_the_old_functor` pins.
 

--- a/BUGS.md
+++ b/BUGS.md
@@ -8,6 +8,19 @@ names the fix. Git holds the story, and a longer entry is noise every agent read
 
 ## Open
 
+### B24. `delegate::operator=` leaks the old functor, so a second pop into one local leaks
+`event_loop::wait_on_all()` keeps one `resume_event event` and pops into it twice: once in the
+`try_pop` drain, once in the `wait_pop_until` loop. Each pop copy-assigns the delegate, and the
+assignment allocates a new functor without freeing the one already held.
+
+ASAN reports `Direct leak of 8 byte(s)` through `delegate::init_functor`
+(`delegate.h:571`) from `concurrent_queue::pop_unlocked` (`concurrent_queue.h:845`). One
+captured reference is 8 bytes, so the leak scales with the capture.
+
+Reproduce it by queuing a callback before `wait_on_all()` runs, so both loops pop. No test did
+that until PR #84 gated a worker that way, and reverting the gate hid it again. The fix belongs
+in `delegate::reset()` or in the copy path which calls it.
+
 ### B23. `set_time_source()` writes a plain pointer a `delay()` worker still reads
 `event_loop::time_source` is a raw pointer. A pending `delay()` reads it once to pick its poll
 branch, then polls `current_time()` from a background worker (`event_loop.h:814-820`). A

--- a/README.md
+++ b/README.md
@@ -1407,25 +1407,25 @@ Fast function delegates as an optimized alternative to `std::function`. Supports
 | Class | Description |
 |-------|-------------|
 | [`delegate<Ret(Args...)>`](src/rpp/delegate.h#L168) | Single-target function delegate |
-| [`multicast_delegate<Ret(Args...)>`](src/rpp/delegate.h#L747) | Multi-target event delegate (`event<>` alias) |
+| [`multicast_delegate<Ret(Args...)>`](src/rpp/delegate.h#L748) | Multi-target event delegate (`event<>` alias) |
 
 ### delegate Methods
 
 | Method | Description |
 |--------|-------------|
-| [`operator()(Args... args)`](src/rpp/delegate.h#L686) | Invoke the delegate |
-| [`operator bool()`](src/rpp/delegate.h#L641) | True if delegate is bound |
-| [`reset()`](src/rpp/delegate.h#L586) | Unbind the delegate |
+| [`operator()(Args... args)`](src/rpp/delegate.h#L687) | Invoke the delegate |
+| [`operator bool()`](src/rpp/delegate.h#L642) | True if delegate is bound |
+| [`reset()`](src/rpp/delegate.h#L587) | Unbind the delegate |
 
 ### multicast_delegate Methods
 
 | Method | Description |
 |--------|-------------|
-| [`add(delegate)`](src/rpp/delegate.h#L830) / [`operator+=`](src/rpp/delegate.h#L890) | Register a callback |
-| [`operator-=`](src/rpp/delegate.h#L895) | Unregister a callback |
-| [`operator()(Args... args)`](src/rpp/delegate.h#L915) | Invoke all registered callbacks |
-| [`clear()`](src/rpp/delegate.h#L744) | Remove all callbacks |
-| [`size()`](src/rpp/delegate.h#L792) | Number of registered callbacks |
+| [`add(delegate)`](src/rpp/delegate.h#L831) / [`operator+=`](src/rpp/delegate.h#L891) | Register a callback |
+| [`operator-=`](src/rpp/delegate.h#L896) | Unregister a callback |
+| [`operator()(Args... args)`](src/rpp/delegate.h#L916) | Invoke all registered callbacks |
+| [`clear()`](src/rpp/delegate.h#L745) | Remove all callbacks |
+| [`size()`](src/rpp/delegate.h#L793) | Number of registered callbacks |
 | [`multicast_fwd<T>`](src/rpp/delegate.h#L910) | Trait to deduce forwarding reference type for multicast args |
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -1407,25 +1407,25 @@ Fast function delegates as an optimized alternative to `std::function`. Supports
 | Class | Description |
 |-------|-------------|
 | [`delegate<Ret(Args...)>`](src/rpp/delegate.h#L168) | Single-target function delegate |
-| [`multicast_delegate<Ret(Args...)>`](src/rpp/delegate.h#L746) | Multi-target event delegate (`event<>` alias) |
+| [`multicast_delegate<Ret(Args...)>`](src/rpp/delegate.h#L747) | Multi-target event delegate (`event<>` alias) |
 
 ### delegate Methods
 
 | Method | Description |
 |--------|-------------|
-| [`operator()(Args... args)`](src/rpp/delegate.h#L685) | Invoke the delegate |
-| [`operator bool()`](src/rpp/delegate.h#L640) | True if delegate is bound |
-| [`reset()`](src/rpp/delegate.h#L585) | Unbind the delegate |
+| [`operator()(Args... args)`](src/rpp/delegate.h#L686) | Invoke the delegate |
+| [`operator bool()`](src/rpp/delegate.h#L641) | True if delegate is bound |
+| [`reset()`](src/rpp/delegate.h#L586) | Unbind the delegate |
 
 ### multicast_delegate Methods
 
 | Method | Description |
 |--------|-------------|
-| [`add(delegate)`](src/rpp/delegate.h#L829) / [`operator+=`](src/rpp/delegate.h#L889) | Register a callback |
-| [`operator-=`](src/rpp/delegate.h#L894) | Unregister a callback |
-| [`operator()(Args... args)`](src/rpp/delegate.h#L914) | Invoke all registered callbacks |
-| [`clear()`](src/rpp/delegate.h#L743) | Remove all callbacks |
-| [`size()`](src/rpp/delegate.h#L791) | Number of registered callbacks |
+| [`add(delegate)`](src/rpp/delegate.h#L830) / [`operator+=`](src/rpp/delegate.h#L890) | Register a callback |
+| [`operator-=`](src/rpp/delegate.h#L895) | Unregister a callback |
+| [`operator()(Args... args)`](src/rpp/delegate.h#L915) | Invoke all registered callbacks |
+| [`clear()`](src/rpp/delegate.h#L744) | Remove all callbacks |
+| [`size()`](src/rpp/delegate.h#L792) | Number of registered callbacks |
 | [`multicast_fwd<T>`](src/rpp/delegate.h#L910) | Trait to deduce forwarding reference type for multicast args |
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -1682,8 +1682,8 @@ Single-threaded event loop that serializes coroutine completions. Unlike `thread
 | [`delay(Duration duration)`](src/rpp/event_loop.h#L838) | Sleep on a background thread, resume on the loop thread |
 | [`delay_until(TimePoint until)`](src/rpp/event_loop.h#L842) | Sleep until a time point, resume on the loop thread |
 | [`stop()`](src/rpp/event_loop.h#L249) | Signal the loop to stop and finalize pending tasks |
-| [`wait_on_all(Duration timeout)`](src/rpp/event_loop.h#L258) | Block until all pending work drains, with timeout. Leaves a resume queued as the count hits zero |
-| [`stop_and_wait_all_ready(Duration max_wait)`](src/rpp/event_loop.h#L267) | Shutdown call: stop, wait, run every queued resume, and detach the time source |
+| [`wait_on_all(Duration timeout)`](src/rpp/event_loop.h#L258) | Block until all pending work drains, with timeout. Leaves a resume queued as the background task count hits zero |
+| [`stop_and_wait_all_ready(Duration max_wait)`](src/rpp/event_loop.h#L267) | Stop, wait for the background tasks, run every queued resume, and detach the time source |
 | [`set_except_handler(handler)`](src/rpp/event_loop.h#L273) | Set custom exception handler for unhandled background errors |
 | [`has_pending_work()`](src/rpp/event_loop.h#L241) | True if any background tasks or resume events are pending |
 | [`background_tasks()`](src/rpp/event_loop.h#L232) | Number of tasks currently suspended in background work |

--- a/README.md
+++ b/README.md
@@ -1609,7 +1609,7 @@ Neither is a future: there is no `get()`/`wait()`/`.then()` — drive by `co_awa
 | [`done()`](src/rpp/task.h#L178) | True once resolved; lets a driver poll completion without awaiting (no `wait()`) |
 | [`deferred<T>::start()`](src/rpp/task.h#L232) | Launch a not-yet-awaited deferred (used by `run_until_done`) |
 
-Drive a top-level task to completion with [`event_loop::run_until_done(task<T>&)`](src/rpp/event_loop.h#L346) or [`run_until_done(deferred<T>&)`](src/rpp/event_loop.h#L375).
+Drive a top-level task to completion with [`event_loop::run_until_done(task<T>&)`](src/rpp/event_loop.h#L349) or [`run_until_done(deferred<T>&)`](src/rpp/event_loop.h#L378).
 
 Example: [tests/test_task.cpp](tests/test_task.cpp)
 
@@ -1660,31 +1660,31 @@ Single-threaded event loop that serializes coroutine completions. Unlike `thread
 
 | Method | Description |
 |--------|-------------|
-| [`run_loop()`](src/rpp/event_loop.h#L308) | Run the loop until `stop()` is called, then drain remaining work |
-| [`run_once(Duration timeout)`](src/rpp/event_loop.h#L317) | Process at most one pending resume event; `Duration::zero()` for non-blocking poll |
-| [`run_until_idle()`](src/rpp/event_loop.h#L334) | Run until no background tasks and no pending resume events remain |
-| [`run_until_done(event_task& task)`](src/rpp/event_loop.h#L346) | Drive the loop until the given `event_task` completes, then rethrow on failure |
-| [`run_until_done(task<T>& task)`](src/rpp/event_loop.h#L364) | Pump the loop until the eager `rpp::task<T>` completes; returns its value (or rethrows) |
-| [`pump_until_ready(cfuture<T>&, timeout)`](src/rpp/event_loop.h#L394) | Pump on the owner thread until that one future is ready; `bool`, never blocks past timeout |
-| [`run_until_ready(cfuture<T>&, timeout)`](src/rpp/event_loop.h#L412) | Pump until that future is ready, then return its value; throws on timeout |
-| [`ensure_on_owner_thread(source_location)`](src/rpp/event_loop.h#L425) | Debug check: true if on the loop's owner thread, else logs an error at the call site |
-| [`run_async(Func&& fut_or_cb)`](src/rpp/event_loop.h#L730) | Dispatch future or lambda to thread pool, resume coroutine on the loop thread |
-| [`fork(Func&& coro_factory)`](src/rpp/event_loop.h#L454) | Fork a concurrent coroutine path (fire-and-forget, tracked internally) |
-| [`join_forks(Duration timeout)`](src/rpp/event_loop.h#L929) | Event-driven join: suspend until all forks complete or timeout expires |
-| [`num_forks()`](src/rpp/event_loop.h#L498) | Number of active forked coroutines |
-| [`drain_forks()`](src/rpp/event_loop.h#L506) | Check completed forks for exceptions and clear them |
-| [`await(semaphore&, Duration)`](src/rpp/event_loop.h#L761) | Wait for semaphore signal, resume on loop thread |
-| [`await(concurrent_queue<T>&, T&, Duration)`](src/rpp/event_loop.h#L775) | Pop from queue, resume on loop thread |
-| [`await_pop(concurrent_queue<T>&, Duration)`](src/rpp/event_loop.h#L789) | Pop from queue returning `optional<T>`, resume on loop thread |
-| [`post(delegate<void()> callback)`](src/rpp/event_loop.h#L555) | Post a callback to execute on the loop thread (like `run_on_main_thread`) |
-| [`post_resume(coro_handle<> handle)`](src/rpp/event_loop.h#L547) | Post a raw coroutine handle resume to the loop thread |
-| [`resume_on_loop()`](src/rpp/event_loop.h#L944) | `co_await` to unconditionally reschedule the current coroutine onto the loop thread |
-| [`delay(Duration duration)`](src/rpp/event_loop.h#L838) | Sleep on a background thread, resume on the loop thread |
-| [`delay_until(TimePoint until)`](src/rpp/event_loop.h#L842) | Sleep until a time point, resume on the loop thread |
+| [`run_loop()`](src/rpp/event_loop.h#L311) | Run the loop until `stop()` is called, then drain remaining work |
+| [`run_once(Duration timeout)`](src/rpp/event_loop.h#L320) | Process at most one pending resume event; `Duration::zero()` for non-blocking poll |
+| [`run_until_idle()`](src/rpp/event_loop.h#L337) | Run until no background tasks and no pending resume events remain |
+| [`run_until_done(event_task& task)`](src/rpp/event_loop.h#L349) | Drive the loop until the given `event_task` completes, then rethrow on failure |
+| [`run_until_done(task<T>& task)`](src/rpp/event_loop.h#L367) | Pump the loop until the eager `rpp::task<T>` completes; returns its value (or rethrows) |
+| [`pump_until_ready(cfuture<T>&, timeout)`](src/rpp/event_loop.h#L397) | Pump on the owner thread until that one future is ready; `bool`, never blocks past timeout |
+| [`run_until_ready(cfuture<T>&, timeout)`](src/rpp/event_loop.h#L415) | Pump until that future is ready, then return its value; throws on timeout |
+| [`ensure_on_owner_thread(source_location)`](src/rpp/event_loop.h#L428) | Debug check: true if on the loop's owner thread, else logs an error at the call site |
+| [`run_async(Func&& fut_or_cb)`](src/rpp/event_loop.h#L733) | Dispatch future or lambda to thread pool, resume coroutine on the loop thread |
+| [`fork(Func&& coro_factory)`](src/rpp/event_loop.h#L457) | Fork a concurrent coroutine path (fire-and-forget, tracked internally) |
+| [`join_forks(Duration timeout)`](src/rpp/event_loop.h#L932) | Event-driven join: suspend until all forks complete or timeout expires |
+| [`num_forks()`](src/rpp/event_loop.h#L501) | Number of active forked coroutines |
+| [`drain_forks()`](src/rpp/event_loop.h#L509) | Check completed forks for exceptions and clear them |
+| [`await(semaphore&, Duration)`](src/rpp/event_loop.h#L764) | Wait for semaphore signal, resume on loop thread |
+| [`await(concurrent_queue<T>&, T&, Duration)`](src/rpp/event_loop.h#L778) | Pop from queue, resume on loop thread |
+| [`await_pop(concurrent_queue<T>&, Duration)`](src/rpp/event_loop.h#L792) | Pop from queue returning `optional<T>`, resume on loop thread |
+| [`post(delegate<void()> callback)`](src/rpp/event_loop.h#L558) | Post a callback to execute on the loop thread (like `run_on_main_thread`) |
+| [`post_resume(coro_handle<> handle)`](src/rpp/event_loop.h#L550) | Post a raw coroutine handle resume to the loop thread |
+| [`resume_on_loop()`](src/rpp/event_loop.h#L947) | `co_await` to unconditionally reschedule the current coroutine onto the loop thread |
+| [`delay(Duration duration)`](src/rpp/event_loop.h#L841) | Sleep on a background thread, resume on the loop thread |
+| [`delay_until(TimePoint until)`](src/rpp/event_loop.h#L845) | Sleep until a time point, resume on the loop thread |
 | [`stop()`](src/rpp/event_loop.h#L249) | Signal the loop to stop and finalize pending tasks |
 | [`wait_on_all(Duration timeout)`](src/rpp/event_loop.h#L258) | Block until all pending work drains, with timeout. Leaves a resume queued as the background task count hits zero |
-| [`stop_and_wait_all_ready(Duration max_wait)`](src/rpp/event_loop.h#L267) | Stop, wait for the background tasks, run every queued resume, and detach the time source |
-| [`set_except_handler(handler)`](src/rpp/event_loop.h#L273) | Set custom exception handler for unhandled background errors |
+| [`stop_and_wait_all_ready(Duration max_wait)`](src/rpp/event_loop.h#L270) | Stop, wait for the background tasks, run every queued resume, and detach the time source |
+| [`set_except_handler(handler)`](src/rpp/event_loop.h#L276) | Set custom exception handler for unhandled background errors |
 | [`has_pending_work()`](src/rpp/event_loop.h#L241) | True if any background tasks or resume events are pending |
 | [`background_tasks()`](src/rpp/event_loop.h#L232) | Number of tasks currently suspended in background work |
 | [`pending_completions()`](src/rpp/event_loop.h#L238) | Number of pending resume events queued for the loop thread |

--- a/README.md
+++ b/README.md
@@ -1609,7 +1609,7 @@ Neither is a future: there is no `get()`/`wait()`/`.then()` — drive by `co_awa
 | [`done()`](src/rpp/task.h#L178) | True once resolved; lets a driver poll completion without awaiting (no `wait()`) |
 | [`deferred<T>::start()`](src/rpp/task.h#L232) | Launch a not-yet-awaited deferred (used by `run_until_done`) |
 
-Drive a top-level task to completion with [`event_loop::run_until_done(task<T>&)`](src/rpp/event_loop.h#L333) or [`run_until_done(deferred<T>&)`](src/rpp/event_loop.h#L362).
+Drive a top-level task to completion with [`event_loop::run_until_done(task<T>&)`](src/rpp/event_loop.h#L346) or [`run_until_done(deferred<T>&)`](src/rpp/event_loop.h#L375).
 
 Example: [tests/test_task.cpp](tests/test_task.cpp)
 
@@ -1660,34 +1660,35 @@ Single-threaded event loop that serializes coroutine completions. Unlike `thread
 
 | Method | Description |
 |--------|-------------|
-| [`run_loop()`](src/rpp/event_loop.h#L295) | Run the loop until `stop()` is called, then drain remaining work |
-| [`run_once(Duration timeout)`](src/rpp/event_loop.h#L304) | Process at most one pending resume event; `Duration::zero()` for non-blocking poll |
-| [`run_until_idle()`](src/rpp/event_loop.h#L321) | Run until no background tasks and no pending resume events remain |
-| [`run_until_done(event_task& task)`](src/rpp/event_loop.h#L333) | Drive the loop until the given `event_task` completes, then rethrow on failure |
-| [`run_until_done(task<T>& task)`](src/rpp/event_loop.h#L351) | Pump the loop until the eager `rpp::task<T>` completes; returns its value (or rethrows) |
-| [`pump_until_ready(cfuture<T>&, timeout)`](src/rpp/event_loop.h#L381) | Pump on the owner thread until that one future is ready; `bool`, never blocks past timeout |
-| [`run_until_ready(cfuture<T>&, timeout)`](src/rpp/event_loop.h#L399) | Pump until that future is ready, then return its value; throws on timeout |
-| [`ensure_on_owner_thread(source_location)`](src/rpp/event_loop.h#L412) | Debug check: true if on the loop's owner thread, else logs an error at the call site |
-| [`run_async(Func&& fut_or_cb)`](src/rpp/event_loop.h#L717) | Dispatch future or lambda to thread pool, resume coroutine on the loop thread |
-| [`fork(Func&& coro_factory)`](src/rpp/event_loop.h#L441) | Fork a concurrent coroutine path (fire-and-forget, tracked internally) |
-| [`join_forks(Duration timeout)`](src/rpp/event_loop.h#L916) | Event-driven join: suspend until all forks complete or timeout expires |
-| [`num_forks()`](src/rpp/event_loop.h#L485) | Number of active forked coroutines |
-| [`drain_forks()`](src/rpp/event_loop.h#L493) | Check completed forks for exceptions and clear them |
-| [`await(semaphore&, Duration)`](src/rpp/event_loop.h#L748) | Wait for semaphore signal, resume on loop thread |
-| [`await(concurrent_queue<T>&, T&, Duration)`](src/rpp/event_loop.h#L762) | Pop from queue, resume on loop thread |
-| [`await_pop(concurrent_queue<T>&, Duration)`](src/rpp/event_loop.h#L776) | Pop from queue returning `optional<T>`, resume on loop thread |
-| [`post(delegate<void()> callback)`](src/rpp/event_loop.h#L542) | Post a callback to execute on the loop thread (like `run_on_main_thread`) |
-| [`post_resume(coro_handle<> handle)`](src/rpp/event_loop.h#L534) | Post a raw coroutine handle resume to the loop thread |
-| [`resume_on_loop()`](src/rpp/event_loop.h#L931) | `co_await` to unconditionally reschedule the current coroutine onto the loop thread |
-| [`delay(Duration duration)`](src/rpp/event_loop.h#L825) | Sleep on a background thread, resume on the loop thread |
-| [`delay_until(TimePoint until)`](src/rpp/event_loop.h#L829) | Sleep until a time point, resume on the loop thread |
-| [`stop()`](src/rpp/event_loop.h#L247) | Signal the loop to stop and finalize pending tasks |
-| [`wait_on_all(Duration timeout)`](src/rpp/event_loop.h#L254) | Block until all pending work drains, with timeout |
-| [`set_except_handler(handler)`](src/rpp/event_loop.h#L260) | Set custom exception handler for unhandled background errors |
-| [`has_pending_work()`](src/rpp/event_loop.h#L239) | True if any background tasks or resume events are pending |
-| [`background_tasks()`](src/rpp/event_loop.h#L230) | Number of tasks currently suspended in background work |
-| [`pending_completions()`](src/rpp/event_loop.h#L236) | Number of pending resume events queued for the loop thread |
-| [`main_thread_id()`](src/rpp/event_loop.h#L242) | Thread ID of the loop's owner thread |
+| [`run_loop()`](src/rpp/event_loop.h#L308) | Run the loop until `stop()` is called, then drain remaining work |
+| [`run_once(Duration timeout)`](src/rpp/event_loop.h#L317) | Process at most one pending resume event; `Duration::zero()` for non-blocking poll |
+| [`run_until_idle()`](src/rpp/event_loop.h#L334) | Run until no background tasks and no pending resume events remain |
+| [`run_until_done(event_task& task)`](src/rpp/event_loop.h#L346) | Drive the loop until the given `event_task` completes, then rethrow on failure |
+| [`run_until_done(task<T>& task)`](src/rpp/event_loop.h#L364) | Pump the loop until the eager `rpp::task<T>` completes; returns its value (or rethrows) |
+| [`pump_until_ready(cfuture<T>&, timeout)`](src/rpp/event_loop.h#L394) | Pump on the owner thread until that one future is ready; `bool`, never blocks past timeout |
+| [`run_until_ready(cfuture<T>&, timeout)`](src/rpp/event_loop.h#L412) | Pump until that future is ready, then return its value; throws on timeout |
+| [`ensure_on_owner_thread(source_location)`](src/rpp/event_loop.h#L425) | Debug check: true if on the loop's owner thread, else logs an error at the call site |
+| [`run_async(Func&& fut_or_cb)`](src/rpp/event_loop.h#L730) | Dispatch future or lambda to thread pool, resume coroutine on the loop thread |
+| [`fork(Func&& coro_factory)`](src/rpp/event_loop.h#L454) | Fork a concurrent coroutine path (fire-and-forget, tracked internally) |
+| [`join_forks(Duration timeout)`](src/rpp/event_loop.h#L929) | Event-driven join: suspend until all forks complete or timeout expires |
+| [`num_forks()`](src/rpp/event_loop.h#L498) | Number of active forked coroutines |
+| [`drain_forks()`](src/rpp/event_loop.h#L506) | Check completed forks for exceptions and clear them |
+| [`await(semaphore&, Duration)`](src/rpp/event_loop.h#L761) | Wait for semaphore signal, resume on loop thread |
+| [`await(concurrent_queue<T>&, T&, Duration)`](src/rpp/event_loop.h#L775) | Pop from queue, resume on loop thread |
+| [`await_pop(concurrent_queue<T>&, Duration)`](src/rpp/event_loop.h#L789) | Pop from queue returning `optional<T>`, resume on loop thread |
+| [`post(delegate<void()> callback)`](src/rpp/event_loop.h#L555) | Post a callback to execute on the loop thread (like `run_on_main_thread`) |
+| [`post_resume(coro_handle<> handle)`](src/rpp/event_loop.h#L547) | Post a raw coroutine handle resume to the loop thread |
+| [`resume_on_loop()`](src/rpp/event_loop.h#L944) | `co_await` to unconditionally reschedule the current coroutine onto the loop thread |
+| [`delay(Duration duration)`](src/rpp/event_loop.h#L838) | Sleep on a background thread, resume on the loop thread |
+| [`delay_until(TimePoint until)`](src/rpp/event_loop.h#L842) | Sleep until a time point, resume on the loop thread |
+| [`stop()`](src/rpp/event_loop.h#L249) | Signal the loop to stop and finalize pending tasks |
+| [`wait_on_all(Duration timeout)`](src/rpp/event_loop.h#L258) | Block until all pending work drains, with timeout. Leaves a resume queued as the count hits zero |
+| [`stop_and_wait_all_ready(Duration max_wait)`](src/rpp/event_loop.h#L267) | Shutdown call: stop, wait, run every queued resume, and detach the time source |
+| [`set_except_handler(handler)`](src/rpp/event_loop.h#L273) | Set custom exception handler for unhandled background errors |
+| [`has_pending_work()`](src/rpp/event_loop.h#L241) | True if any background tasks or resume events are pending |
+| [`background_tasks()`](src/rpp/event_loop.h#L232) | Number of tasks currently suspended in background work |
+| [`pending_completions()`](src/rpp/event_loop.h#L238) | Number of pending resume events queued for the loop thread |
+| [`main_thread_id()`](src/rpp/event_loop.h#L244) | Thread ID of the loop's owner thread |
 
 ### event_task Methods
 

--- a/src/rpp/delegate.h
+++ b/src/rpp/delegate.h
@@ -182,6 +182,7 @@ namespace rpp
             }
             else
             {
+                to.reset(); // a function source frees whatever functor `to` already owns
                 to.f = f;
                 to.obj = obj;
             }

--- a/src/rpp/delegate.h
+++ b/src/rpp/delegate.h
@@ -174,6 +174,7 @@ namespace rpp
 
         void copy(delegate& to) const noexcept
         {
+            if (this == &to) return; // a self copy has nothing to do, and both branches free first
             if (destructor) // looks like we have a functor
             {
                 proxy_copy(obj, to);

--- a/src/rpp/event_loop.cpp
+++ b/src/rpp/event_loop.cpp
@@ -86,9 +86,11 @@ namespace rpp
         wait_on_all(max_wait);
         const bool tasks_done = !has_background_tasks(); // before the drain, so a late worker still counts
         run_all_ready(); // a resume queued as the background count hit zero is still pending
-        if (tasks_done)
+        // a drained resume can start new work, so the detach reads the count again
+        const bool idle = !has_pending_work();
+        if (idle)
             set_time_source(nullptr); // a live delay() worker polls it against a virtual deadline
-        return tasks_done && !has_pending_work();
+        return tasks_done && idle;
     }
 
     bool event_loop::run_loop(rpp::Duration suspend_interval) noexcept

--- a/src/rpp/event_loop.cpp
+++ b/src/rpp/event_loop.cpp
@@ -75,11 +75,20 @@ namespace rpp
 
     bool event_loop::stop_and_wait_all_ready(rpp::Duration max_wait) noexcept
     {
+        // the drain resumes coroutines, which must run on the loop thread
+        if (rpp::get_thread_id() != owner_thread_id.load(std::memory_order_acquire))
+        {
+            LogError("event_loop::stop_and_wait_all_ready() must be called on the event loop thread");
+            return false;
+        }
+
         stop();
         wait_on_all(max_wait);
+        const bool tasks_done = !has_background_tasks(); // before the drain, so a late worker still counts
         run_all_ready(); // a resume queued as the background count hit zero is still pending
-        set_time_source(nullptr);
-        return !has_pending_work();
+        if (tasks_done)
+            set_time_source(nullptr); // a live delay() worker polls it against a virtual deadline
+        return tasks_done && !has_pending_work();
     }
 
     bool event_loop::run_loop(rpp::Duration suspend_interval) noexcept

--- a/src/rpp/event_loop.cpp
+++ b/src/rpp/event_loop.cpp
@@ -73,6 +73,15 @@ namespace rpp
         return resume_queue.empty() && !has_background_tasks();
     }
 
+    bool event_loop::stop_and_wait_all_ready(rpp::Duration max_wait) noexcept
+    {
+        stop();
+        wait_on_all(max_wait);
+        run_all_ready(); // a resume queued as the background count hit zero is still pending
+        set_time_source(nullptr);
+        return !has_background_tasks() && resume_queue.empty();
+    }
+
     bool event_loop::run_loop(rpp::Duration suspend_interval) noexcept
     {
         // keep processing until stop() is called and pending tasks are completed

--- a/src/rpp/event_loop.cpp
+++ b/src/rpp/event_loop.cpp
@@ -87,7 +87,8 @@ namespace rpp
         const bool tasks_done = !has_background_tasks(); // before the drain, so a late worker still counts
         run_all_ready(); // a resume queued as the background count hit zero is still pending
         // a drained resume can start new work, so the detach reads the count again
-        const bool idle = !has_pending_work();
+        // a fork suspended on a post_resume() awaiter counts in neither, so it gets its own term
+        const bool idle = !has_pending_work() && num_forks() == 0;
         if (idle)
             set_time_source(nullptr); // a live delay() worker polls it against a virtual deadline
         return tasks_done && idle;

--- a/src/rpp/event_loop.cpp
+++ b/src/rpp/event_loop.cpp
@@ -79,7 +79,7 @@ namespace rpp
         wait_on_all(max_wait);
         run_all_ready(); // a resume queued as the background count hit zero is still pending
         set_time_source(nullptr);
-        return !has_background_tasks() && resume_queue.empty();
+        return !has_pending_work();
     }
 
     bool event_loop::run_loop(rpp::Duration suspend_interval) noexcept

--- a/src/rpp/event_loop.h
+++ b/src/rpp/event_loop.h
@@ -204,8 +204,8 @@ namespace rpp
         event_loop(rpp::uint64 main_thr_id = 0/*0=rpp::get_thread_id()*/,
                    rpp::thread_pool* background_task_pool RPP_LIFETIMEBOUND = nullptr,
                    rpp::AtomicTimeSource* warpable_clock RPP_LIFETIMEBOUND = nullptr) noexcept;
-        /** @brief Reads the time source while it drains, so the owner must outlive the loop
-         *         or detach the clock first. stop_and_wait_all_ready() detaches it. */
+        /** @brief The destructor drains pending work and reads the time source, so the owner must
+         *         outlive the loop. stop_and_wait_all_ready() detaches the time source first. */
         ~event_loop() noexcept;
         NOCOPY_NOMOVE(event_loop)
 
@@ -258,9 +258,9 @@ namespace rpp
         bool wait_on_all(rpp::Duration timeout = rpp::seconds(1)) noexcept;
 
         /**
-         * @brief Shuts the loop down: stops it, waits for the background tasks, runs every
-         *        resume they queued, and detaches the time source. The destructor then
-         *        touches nothing the owner may already have destroyed.
+         * @brief Stops the loop, waits for the background tasks, runs every resume they
+         *        queued, and detaches the time source. The destructor then touches nothing
+         *        the owner may already have destroyed.
          * @param max_wait Maximum time to wait for the background tasks.
          * @returns true when the loop drained inside max_wait, leaving no task and no resume
          */

--- a/src/rpp/event_loop.h
+++ b/src/rpp/event_loop.h
@@ -261,8 +261,11 @@ namespace rpp
          * @brief Stops the loop, waits for the background tasks, runs every resume they
          *        queued, and detaches the time source. The destructor then touches nothing
          *        the owner may already have destroyed.
+         *        On timeout the time source stays attached, because a live delay() worker
+         *        polls it against a virtual deadline and would never reach a wall-clock one.
+         *        Call it on the loop thread, because the drain resumes coroutines.
          * @param max_wait Maximum time to wait for the background tasks.
-         * @returns true when the loop drained inside max_wait, leaving no task and no resume
+         * @returns true when every task finished inside max_wait and nothing is left queued
          */
         bool stop_and_wait_all_ready(rpp::Duration max_wait = rpp::seconds(1)) noexcept;
 

--- a/src/rpp/event_loop.h
+++ b/src/rpp/event_loop.h
@@ -204,6 +204,8 @@ namespace rpp
         event_loop(rpp::uint64 main_thr_id = 0/*0=rpp::get_thread_id()*/,
                    rpp::thread_pool* background_task_pool RPP_LIFETIMEBOUND = nullptr,
                    rpp::AtomicTimeSource* warpable_clock RPP_LIFETIMEBOUND = nullptr) noexcept;
+        /** @brief Reads the time source while it drains, so the owner must outlive the loop
+         *         or detach the clock first. stop_and_wait_all_ready() detaches it. */
         ~event_loop() noexcept;
         NOCOPY_NOMOVE(event_loop)
 
@@ -247,11 +249,22 @@ namespace rpp
         void stop() noexcept;
 
         /**
-         * @brief Waits on all pending tasks to fully drain the event loop
+         * @brief Waits on all pending tasks to fully drain the event loop.
+         *        This is not a complete drain. A resume queued as the background count reaches
+         *        zero stays queued, so a shutdown path wants stop_and_wait_all_ready() instead.
          * @param timeout Maximum time to wait for pending tasks to complete.
          * @returns true if all tasks were completed within timeout
          */
         bool wait_on_all(rpp::Duration timeout = rpp::seconds(1)) noexcept;
+
+        /**
+         * @brief Shuts the loop down: stops it, waits for the background tasks, runs every
+         *        resume they queued, and detaches the time source. The destructor then
+         *        touches nothing the owner may already have destroyed.
+         * @param max_wait Maximum time to wait for the background tasks.
+         * @returns true when the loop drained inside max_wait, leaving no task and no resume
+         */
+        bool stop_and_wait_all_ready(rpp::Duration max_wait = rpp::seconds(1)) noexcept;
 
         /**
          * @brief By default exceptions are swallowed and logged as warnings.

--- a/tests/test_delegate.cpp
+++ b/tests/test_delegate.cpp
@@ -923,6 +923,15 @@ namespace rpp
 
             held = plain; // a second assign has nothing left to free
             AssertThat(destroyed, base + 1);
+
+            // a self copy must survive: both branches free the destination before they read
+            plain.copy(const_cast<rpp::delegate<void()>&>(plain));
+            AssertThat(plain.good(), true);
+
+            rpp::delegate<void()> functor { tracked{} };
+            functor.copy(functor);
+            AssertThat(functor.good(), true);
+            functor(); // the functor is still callable, not freed
         }
 
         ////////////////////////////////////////////////////

--- a/tests/test_delegate.cpp
+++ b/tests/test_delegate.cpp
@@ -901,7 +901,7 @@ namespace rpp
         ////////////////////////////////////////////////////
 
         // a function source overwrote the pointers and left the old functor allocated,
-        // which ASAN reported as a leak. see BUGS.md B24
+        // which ASAN reported as a leak. see BUGS.md C29
         TestCase(copy_assign_from_function_frees_the_old_functor)
         {
             static int destroyed = 0;

--- a/tests/test_delegate.cpp
+++ b/tests/test_delegate.cpp
@@ -899,6 +899,33 @@ namespace rpp
         }
 
         ////////////////////////////////////////////////////
+
+        // a function source overwrote the pointers and left the old functor allocated,
+        // which ASAN reported as a leak. see BUGS.md B24
+        TestCase(copy_assign_from_function_frees_the_old_functor)
+        {
+            static int destroyed = 0;
+            destroyed = 0;
+            struct tracked
+            {
+                int payload = 0;
+                ~tracked() { ++destroyed; }
+                void operator()() const noexcept {}
+            };
+            struct plain_source { static void func() noexcept {} };
+
+            rpp::delegate<void()> held { tracked{} };
+            const rpp::delegate<void()> plain { &plain_source::func };
+            const int base = destroyed; // the source temporary already died
+
+            held = plain; // the functor `held` owns must be freed here, not leaked
+            AssertThat(destroyed, base + 1);
+
+            held = plain; // a second assign has nothing left to free
+            AssertThat(destroyed, base + 1);
+        }
+
+        ////////////////////////////////////////////////////
     };
     
     // NOLINTEND(performance-*,readability-make-member-function-const,bugprone-exception-escape)

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -1169,11 +1169,13 @@ TestImpl(test_event_loop)
     }
 
     // posts a callback from the final resume, which lands as the background count hits zero
-    void fork_with_trailing_post(std::atomic_bool& trailing_ran)
+    void fork_with_trailing_post(std::atomic_bool& trailing_ran, rpp::semaphore& gate)
     {
-        loop->fork([this, &trailing_ran]() -> rpp::event_task
+        loop->fork([this, &trailing_ran, &gate]() -> rpp::event_task
         {
-            co_await loop->run_async([]{ rpp::sleep_ms(5); });
+            // the gate opens inside wait_on_all's first drain, so the sleep gives the owner
+            // thread a wide margin to leave that drain before this resume lands
+            co_await loop->run_async([&gate]{ gate.wait(); rpp::sleep_ms(5); });
             // the worker pushes the resume before it decrements, so wait for the count
             while (loop->has_background_tasks()) // else wait_on_all drains the post it left
                 rpp::yield();
@@ -1214,7 +1216,10 @@ TestImpl(test_event_loop)
     TestCase(wait_on_all_leaves_a_trailing_post)
     {
         std::atomic_bool trailing_ran { false };
-        fork_with_trailing_post(trailing_ran);
+        rpp::semaphore gate;
+        fork_with_trailing_post(trailing_ran, gate);
+        // wait_on_all drains this first, so the worker only runs once the owner thread is inside it
+        loop->post([&gate]{ gate.notify(); });
 
         loop->wait_on_all(rpp::seconds(1));
         AssertThat(trailing_ran.load(), false); // still queued, which is why the shutdown call exists
@@ -1227,7 +1232,9 @@ TestImpl(test_event_loop)
     TestCase(stop_and_wait_all_ready_drains_and_detaches)
     {
         std::atomic_bool trailing_ran { false };
-        fork_with_trailing_post(trailing_ran);
+        rpp::semaphore gate;
+        fork_with_trailing_post(trailing_ran, gate);
+        gate.notify(); // this case only needs the post to run, not which drain runs it
         clock.warp_forward(rpp::seconds(10000));
 
         AssertTrue(loop->stop_and_wait_all_ready(rpp::seconds(1)));

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -1199,6 +1199,15 @@ TestImpl(test_event_loop)
         });
     }
 
+    // parks the coroutine handle instead of starting background work, so neither counter sees it
+    struct parking_awaiter
+    {
+        rpp::coro_handle<>& slot;
+        bool await_ready() const noexcept { return false; }
+        void await_suspend(rpp::coro_handle<> h) noexcept { slot = h; }
+        void await_resume() const noexcept {}
+    };
+
     // ─── shutdown: wait_on_all is not a complete drain ──────────
     // the resume lands as the background count reaches zero, past the point wait_on_all rechecks
     TestCase(wait_on_all_leaves_a_trailing_post)
@@ -1243,6 +1252,21 @@ TestImpl(test_event_loop)
         AssertGreater(loop->current_time(), rpp::TimePoint::monotonic_now() + rpp::seconds(9000));
 
         release.notify();
+        AssertTrue(loop->stop_and_wait_all_ready(rpp::seconds(1)));
+    }
+
+    // ─── shutdown: a suspended fork blocks completion ───────────
+    // it runs no background task and queues no resume, so num_forks() is the only signal
+    TestCase(stop_and_wait_all_ready_counts_a_suspended_fork)
+    {
+        rpp::coro_handle<> parked {};
+        loop->fork([&]() -> rpp::event_task { co_await parking_awaiter{ parked }; });
+        clock.warp_forward(rpp::seconds(10000));
+
+        AssertFalse(loop->stop_and_wait_all_ready(rpp::millis(20)));
+        AssertGreater(loop->current_time(), rpp::TimePoint::monotonic_now() + rpp::seconds(9000));
+
+        loop->post_resume(parked);
         AssertTrue(loop->stop_and_wait_all_ready(rpp::seconds(1)));
     }
 

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -1167,6 +1167,41 @@ TestImpl(test_event_loop)
         AssertThat(bg_finished.load(), true);
     }
 
+    // posts a callback from the final resume, which lands as the background count hits zero
+    void fork_with_trailing_post(std::atomic_bool& trailing_ran)
+    {
+        loop->fork([this, &trailing_ran]() -> rpp::event_task
+        {
+            co_await loop->run_async([]{ rpp::sleep_ms(5); });
+            loop->post([&trailing_ran]{ trailing_ran = true; });
+        });
+    }
+
+    TestCase(wait_on_all_leaves_a_trailing_post)
+    {
+        std::atomic_bool trailing_ran { false };
+        fork_with_trailing_post(trailing_ran);
+
+        loop->wait_on_all(rpp::seconds(1));
+        AssertThat(trailing_ran.load(), false); // still queued, which is why the shutdown call exists
+
+        loop->run_all_ready();
+        AssertThat(trailing_ran.load(), true);
+    }
+
+    TestCase(stop_and_wait_all_ready_drains_and_detaches)
+    {
+        std::atomic_bool trailing_ran { false };
+        fork_with_trailing_post(trailing_ran);
+        clock.warp_forward(rpp::seconds(10000));
+
+        AssertTrue(loop->stop_and_wait_all_ready(rpp::seconds(1)));
+        AssertThat(trailing_ran.load(), true);
+
+        // detached: current_time() reads the wall clock, not the warped source
+        AssertLess(loop->current_time(), clock.time_now() - rpp::seconds(9000));
+    }
+
     // ─── loop hook: fires on every run_once() ───────────────────
     // run_once() always invokes the hook, whether or not an event was processed.
     TestCase(loop_hook_invoked_by_run_once)

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -1181,6 +1181,24 @@ TestImpl(test_event_loop)
         });
     }
 
+    // the trailing post starts a blocked task, so run_all_ready() leaves the loop busy
+    void fork_with_trailing_post_starting(rpp::semaphore& release)
+    {
+        loop->fork([this, &release]() -> rpp::event_task
+        {
+            co_await loop->run_async([]{ rpp::sleep_ms(5); });
+            while (loop->has_background_tasks())
+                rpp::yield();
+            loop->post([this, &release]
+            {
+                loop->fork([this, &release]() -> rpp::event_task
+                {
+                    co_await loop->run_async([&release]{ release.wait(); });
+                });
+            });
+        });
+    }
+
     // ─── shutdown: wait_on_all is not a complete drain ──────────
     // the resume lands as the background count reaches zero, past the point wait_on_all rechecks
     TestCase(wait_on_all_leaves_a_trailing_post)
@@ -1222,6 +1240,21 @@ TestImpl(test_event_loop)
         clock.warp_forward(rpp::seconds(10000));
         AssertFalse(loop->stop_and_wait_all_ready(rpp::millis(20)));
         // still attached: current_time() carries the warp, a detached loop would read wall time
+        AssertGreater(loop->current_time(), rpp::TimePoint::monotonic_now() + rpp::seconds(9000));
+
+        release.notify();
+        AssertTrue(loop->stop_and_wait_all_ready(rpp::seconds(1)));
+    }
+
+    // ─── shutdown: work started inside the drain keeps the clock ─
+    // run_all_ready() resumes a coroutine which starts a new task, so the pre-drain count is stale
+    TestCase(stop_and_wait_all_ready_keeps_the_clock_for_work_started_in_the_drain)
+    {
+        rpp::semaphore release;
+        fork_with_trailing_post_starting(release);
+        clock.warp_forward(rpp::seconds(10000));
+
+        AssertFalse(loop->stop_and_wait_all_ready(rpp::seconds(1)));
         AssertGreater(loop->current_time(), rpp::TimePoint::monotonic_now() + rpp::seconds(9000));
 
         release.notify();

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -5,6 +5,7 @@
 #include <rpp/timer.h>
 #include <rpp/threads.h>
 #include <rpp/collections.h>
+#include <rpp/semaphore.h>
 
 #include <rpp/tests.h>
 #include <atomic>
@@ -1173,6 +1174,9 @@ TestImpl(test_event_loop)
         loop->fork([this, &trailing_ran]() -> rpp::event_task
         {
             co_await loop->run_async([]{ rpp::sleep_ms(5); });
+            // the worker pushes the resume before it decrements, so wait for the count
+            while (loop->has_background_tasks()) // else wait_on_all drains the post it left
+                rpp::yield();
             loop->post([&trailing_ran]{ trailing_ran = true; });
         });
     }
@@ -1203,6 +1207,25 @@ TestImpl(test_event_loop)
 
         // detached: current_time() reads the wall clock, not the warped source
         AssertLess(loop->current_time(), clock.time_now() - rpp::seconds(9000));
+    }
+
+    // ─── shutdown: a timeout keeps the time source attached ─────
+    // a live delay() worker polls it against a virtual deadline and would never reach a wall-clock one
+    TestCase(stop_and_wait_all_ready_keeps_the_clock_on_timeout)
+    {
+        rpp::semaphore release;
+        loop->fork([&]() -> rpp::event_task
+        {
+            co_await loop->run_async([&]{ release.wait(); });
+        });
+
+        clock.warp_forward(rpp::seconds(10000));
+        AssertFalse(loop->stop_and_wait_all_ready(rpp::millis(20)));
+        // still attached: current_time() carries the warp, a detached loop would read wall time
+        AssertGreater(loop->current_time(), rpp::TimePoint::monotonic_now() + rpp::seconds(9000));
+
+        release.notify();
+        AssertTrue(loop->stop_and_wait_all_ready(rpp::seconds(1)));
     }
 
     // ─── loop hook: fires on every run_once() ───────────────────

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -1266,7 +1266,8 @@ TestImpl(test_event_loop)
         fork_with_trailing_post_starting(release);
         clock.warp_forward(rpp::seconds(10000));
 
-        AssertFalse(loop->stop_and_wait_all_ready(rpp::seconds(1)));
+        // the blocked task never finishes, so a short wait costs 20ms instead of a full second
+        AssertFalse(loop->stop_and_wait_all_ready(rpp::millis(20)));
         AssertGreater(loop->current_time(), rpp::TimePoint::monotonic_now() + rpp::seconds(9000));
 
         release.notify();

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -1203,6 +1203,7 @@ TestImpl(test_event_loop)
     struct parking_awaiter
     {
         rpp::coro_handle<>& slot;
+        // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
         bool await_ready() const noexcept { return false; }
         void await_suspend(rpp::coro_handle<> h) noexcept { slot = h; }
         void await_resume() const noexcept {}

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -1169,15 +1169,14 @@ TestImpl(test_event_loop)
     }
 
     // posts a callback from the final resume, which lands as the background count hits zero
-    void fork_with_trailing_post(std::atomic_bool& trailing_ran, rpp::semaphore& gate)
+    void fork_with_trailing_post(std::atomic_bool& trailing_ran)
     {
-        loop->fork([this, &trailing_ran, &gate]() -> rpp::event_task
+        loop->fork([this, &trailing_ran]() -> rpp::event_task
         {
-            // the gate opens inside wait_on_all's first drain, so the sleep gives the owner
-            // thread a wide margin to leave that drain before this resume lands
-            co_await loop->run_async([&gate]{ gate.wait(); rpp::sleep_ms(5); });
-            // the worker pushes the resume before it decrements, so wait for the count
-            while (loop->has_background_tasks()) // else wait_on_all drains the post it left
+            co_await loop->run_async([]{ rpp::sleep_ms(5); });
+            // the worker pushes the resume before it decrements, so the post must wait for
+            // the count, or wait_on_all drains it in the same pass and the drain proves nothing
+            while (loop->has_background_tasks())
                 rpp::yield();
             loop->post([&trailing_ran]{ trailing_ran = true; });
         });
@@ -1189,7 +1188,7 @@ TestImpl(test_event_loop)
         loop->fork([this, &release]() -> rpp::event_task
         {
             co_await loop->run_async([]{ rpp::sleep_ms(5); });
-            while (loop->has_background_tasks())
+            while (loop->has_background_tasks()) // the fork must start inside run_all_ready()
                 rpp::yield();
             loop->post([this, &release]
             {
@@ -1211,30 +1210,11 @@ TestImpl(test_event_loop)
         void await_resume() const noexcept {}
     };
 
-    // ─── shutdown: wait_on_all is not a complete drain ──────────
-    // the resume lands as the background count reaches zero, past the point wait_on_all rechecks
-    TestCase(wait_on_all_leaves_a_trailing_post)
-    {
-        std::atomic_bool trailing_ran { false };
-        rpp::semaphore gate;
-        fork_with_trailing_post(trailing_ran, gate);
-        // wait_on_all drains this first, so the worker only runs once the owner thread is inside it
-        loop->post([&gate]{ gate.notify(); });
-
-        loop->wait_on_all(rpp::seconds(1));
-        AssertThat(trailing_ran.load(), false); // still queued, which is why the shutdown call exists
-
-        loop->run_all_ready();
-        AssertThat(trailing_ran.load(), true);
-    }
-
     // ─── shutdown: the one call that drains and detaches ────────
     TestCase(stop_and_wait_all_ready_drains_and_detaches)
     {
         std::atomic_bool trailing_ran { false };
-        rpp::semaphore gate;
-        fork_with_trailing_post(trailing_ran, gate);
-        gate.notify(); // this case only needs the post to run, not which drain runs it
+        fork_with_trailing_post(trailing_ran);
         clock.warp_forward(rpp::seconds(10000));
 
         AssertTrue(loop->stop_and_wait_all_ready(rpp::seconds(1)));

--- a/tests/test_event_loop.cpp
+++ b/tests/test_event_loop.cpp
@@ -1177,6 +1177,8 @@ TestImpl(test_event_loop)
         });
     }
 
+    // ─── shutdown: wait_on_all is not a complete drain ──────────
+    // the resume lands as the background count reaches zero, past the point wait_on_all rechecks
     TestCase(wait_on_all_leaves_a_trailing_post)
     {
         std::atomic_bool trailing_ran { false };
@@ -1189,6 +1191,7 @@ TestImpl(test_event_loop)
         AssertThat(trailing_ran.load(), true);
     }
 
+    // ─── shutdown: the one call that drains and detaches ────────
     TestCase(stop_and_wait_all_ready_drains_and_detaches)
     {
         std::atomic_bool trailing_ran { false };


### PR DESCRIPTION
Closes #83. Also fixes #85, a delegate leak this work uncovered.

## What

A shutdown path spelled four calls, and dropping any one of them crashed:

```cpp
loop->stop();
loop->wait_on_all();
loop->run_all_ready();
loop->set_time_source(nullptr);
```

One call now:

```cpp
bool event_loop::stop_and_wait_all_ready(rpp::Duration max_wait) noexcept
{
    // the drain resumes coroutines, which must run on the loop thread
    if (rpp::get_thread_id() != owner_thread_id.load(std::memory_order_acquire))
    {
        LogError("event_loop::stop_and_wait_all_ready() must be called on the event loop thread");
        return false;
    }

    stop();
    wait_on_all(max_wait);
    const bool tasks_done = !has_background_tasks(); // before the drain, so a late worker still counts
    run_all_ready(); // a resume queued as the background count hit zero is still pending
    // a drained resume can start new work, so the detach reads the count again
    // a fork suspended on a post_resume() awaiter counts in neither, so it gets its own term
    const bool idle = !has_pending_work() && num_forks() == 0;
    if (idle)
        set_time_source(nullptr); // a live delay() worker polls it against a virtual deadline
    return tasks_done && idle;
}
```

## Why the detach is conditional

`delay_awaiter` reads `time_source` once to choose its poll branch (`event_loop.h:814`), then polls `current_time()` against a **virtual** deadline. Detaching under a live worker leaves it comparing that virtual deadline to wall time, so it polls until real time catches up. On a 10000 second warp that is a hang, not a wrong answer.

So `idle` must be true at the moment of the detach, and three different things can make it false. The first draft had one term. Codex found the other two.

| Term | The case it catches | Test |
|---|---|---|
| `!has_background_tasks()` after `wait_on_all` | a worker still running past `max_wait` | `..._keeps_the_clock_on_timeout` |
| the recheck **after** `run_all_ready()` | a drained resume starts a new `run_async()` or `delay()` | `..._keeps_the_clock_for_work_started_in_the_drain` |
| `num_forks() == 0` | a fork parked on a `post_resume()` awaiter, invisible to both counters | `..._counts_a_suspended_fork` |

Delete any one term and its case fails. On failure the clock stays attached and the call returns false, so the caller retries or lets the destructor finish. It does not loop until idle: a loop which keeps generating work would never return.

## The return value

`tasks_done && idle`. `tasks_done` answers "did every task finish inside `max_wait`", read before the drain. `idle` answers "did the drain leave anything".

Forwarding `wait_on_all()`'s own boolean does not work. It is `resume_queue.empty() && !has_background_tasks()`, false exactly when a trailing resume sits in the queue, which is the case this method exists to fix.

## The delegate leak, #85

`delegate::copy()` has two branches and only the functor one freed what the destination owned. The function branch overwrote `f` and `obj` and leaked the functor. `wait_on_all()` pops into one `resume_event` twice, so a functor pop followed by a function pop leaked the first, which ASAN caught once a test queued a callback before the call.

`copy()` also frees the destination before it reads the source, so a self copy destroyed its own input. That was a use after free in the functor branch before this change. One guard covers both, and `copy_assign_from_function_frees_the_old_functor` pins the free and both self copies.

## Tests

Four cases, all under 21ms. Three pin one detach term each. `..._drains_and_detaches` pins the trailing post and the detach together.

R1 proof: with `event_loop.h` and `event_loop.cpp` reverted, the suite fails to compile with `no member named 'stop_and_wait_all_ready'`.

One honest limit. `wait_on_all()` drains chained posts in its first loop, so whether a trailing post lands there or in `run_all_ready()` depends on when the owner thread enters the call, and the loop exposes no signal for the end of that drain. A semaphore gate narrows the window without closing it, and it came out at the owner's request. The cases are cheap and correct either way, and `..._keeps_the_clock_for_work_started_in_the_drain` would go quiet rather than red in the unlucky ordering. A fifth case which asserted that window directly is deleted for the same reason.

## What I did not change

`~event_loop()` still runs `stop()` and `wait_on_all(1000ms)` with no drain and no detach. Its `wait_on_all` drains the queue with `try_pop`, so a trailing post does already run from the destructor. Calling the new method there is a behavior change #83 did not ask for.

BUGS.md **B23** records what is left: `set_time_source()` still writes a plain pointer a live `delay()` worker reads, for any caller which retimes a loop with work in flight. This method no longer reaches it. **C29** records the closed delegate leak.

## Gates

| Gate | Result |
|---|---|
| gcc 13.3 C++23 | PASS 550/550 in 4.38s |
| ASAN, gcc | PASS 550/550, no leaks |
| clang-tidy | PASS 0 on the changed files |
| update_doc_linerefs --check, --check-undocumented | PASS 0, clean |
| check_includes selftest, import-order | PASS 0, 0 |
| gen_module_exports --selftest, --all | PASS 0, 0 over 8 modules |
| Clang, Android, Windows MSVC | NOT RUN here, CI covers them |

## Open thread

One Codex finding stays open, answered rather than changed: it asks for the semaphore gate on `fork_with_trailing_post_starting`. I took the half which cost something, dropping that case from a one second `max_wait` to 20ms, and declined the gate for the reason above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdWSwgQ6ch7yRmBCR8QJFV